### PR TITLE
Use brand color tokens for background utilities

### DIFF
--- a/client/src/components/governance-documents.tsx
+++ b/client/src/components/governance-documents.tsx
@@ -123,7 +123,11 @@ export function GovernanceDocuments() {
           <Button
             key={category}
             variant={selectedCategory === category ? 'default' : 'outline'}
-            className={selectedCategory === category ? 'bg-brand-primary hover:bg-brand-primary-dark text-white border-brand-primary' : 'text-brand-primary border-brand-primary hover:bg-[#f0f9ff]'}
+            className={
+              selectedCategory === category
+                ? 'bg-brand-primary hover:bg-brand-primary-dark text-white border-brand-primary'
+                : 'text-brand-primary border-brand-primary hover:bg-brand-primary/10'
+            }
             size="sm"
             onClick={() => setSelectedCategory(category)}
             className="text-sm"
@@ -179,7 +183,7 @@ export function GovernanceDocuments() {
                   size="sm"
                   variant="outline"
                   onClick={() => handlePreview(document)}
-                  className="w-full h-9 text-sm font-medium text-brand-primary border-brand-primary hover:bg-[#f0f9ff]"
+                  className="w-full h-9 text-sm font-medium text-brand-primary border-brand-primary hover:bg-brand-primary/10"
                 >
                   <Eye className="h-4 w-4 mr-2" />
                   Preview

--- a/client/src/pages/impact-dashboard.tsx
+++ b/client/src/pages/impact-dashboard.tsx
@@ -308,7 +308,7 @@ export default function ImpactDashboard() {
 
         {/* Key Impact Metrics */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-          <Card className="bg-gradient-to-r from-blue-500 to-blue-600 text-white">
+          <Card className="bg-gradient-to-r from-brand-teal to-brand-primary text-white">
             <CardHeader className="pb-2">
               <CardTitle className="text-lg font-medium flex items-center">
                 <Heart className="w-5 h-5 mr-2" />

--- a/client/src/pages/project-detail-clean.tsx
+++ b/client/src/pages/project-detail-clean.tsx
@@ -728,10 +728,10 @@ export default function ProjectDetailClean({
         {/* Support People */}
         <div className="bg-white rounded-lg border border-gray-200 p-4">
           <div className="flex items-center gap-2 mb-3">
-            <div className="w-6 h-6 bg-[#B8860B]/10 rounded flex items-center justify-center shrink-0">
-              <Users className="h-3 w-3 text-[#B8860B]" />
+            <div className="w-6 h-6 bg-brand-gold/10 rounded flex items-center justify-center shrink-0">
+              <Users className="h-3 w-3 text-brand-gold" />
             </div>
-            <h3 className="text-sm font-semibold text-[#B8860B] font-roboto">
+            <h3 className="text-sm font-semibold text-brand-gold font-roboto">
               Support
             </h3>
           </div>

--- a/client/src/pages/sms-opt-in.tsx
+++ b/client/src/pages/sms-opt-in.tsx
@@ -140,7 +140,7 @@ export default function SMSOptInPage() {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin h-8 w-8 border-b-2 border-[#1f7b7b] mx-auto"></div>
+          <div className="animate-spin h-8 w-8 border-b-2 border-brand-teal mx-auto"></div>
           <p className="mt-2 text-gray-600">Loading...</p>
         </div>
       </div>
@@ -186,7 +186,7 @@ export default function SMSOptInPage() {
         <Card>
           <CardHeader className="text-center">
             <div className="flex justify-center mb-4">
-              <div className="bg-[#1f7b7b] p-3 rounded-full">
+              <div className="bg-brand-teal p-3 rounded-full">
                 <MessageSquare className="h-8 w-8 text-white" />
               </div>
             </div>
@@ -312,7 +312,7 @@ export default function SMSOptInPage() {
 
                 <Button
                   type="submit"
-                  className="w-full bg-[#1f7b7b] hover:bg-[#165a5a]"
+                  className="w-full bg-brand-teal hover:bg-brand-teal-dark"
                   disabled={
                     optInMutation.isPending || !consent || !phoneNumber.trim()
                   }

--- a/old_files_backup/obsolete_duplicates/hosts-management.tsx
+++ b/old_files_backup/obsolete_duplicates/hosts-management.tsx
@@ -229,7 +229,7 @@ export default function HostsManagement() {
         <Dialog open={isAddModalOpen} onOpenChange={setIsAddModalOpen}>
           <DialogTrigger asChild>
             <Button
-              className="bg-blue-600 hover:bg-blue-700"
+              className="bg-brand-primary hover:bg-brand-primary-dark"
               disabled={!canEdit}
             >
               <Plus className="w-4 h-4 mr-2" />

--- a/old_files_backup/obsolete_duplicates/projects.tsx
+++ b/old_files_backup/obsolete_duplicates/projects.tsx
@@ -421,7 +421,7 @@ export default function ProjectsPage({
                           e.stopPropagation();
                           handleEdit(project);
                         }}
-                        className="p-1 text-gray-500 hover:text-blue-600 transition-colors"
+                        className="p-1 text-gray-500 hover:text-brand-primary transition-colors"
                         title="Edit project"
                       >
                         <Edit2 className="w-4 h-4" />
@@ -466,7 +466,7 @@ export default function ProjectsPage({
                     </div>
                     <div className="w-full bg-gray-200 rounded-full h-2">
                       <div
-                        className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+                        className="bg-brand-primary h-2 rounded-full transition-all duration-300"
                         style={{ width: `${project.progressPercentage || 0}%` }}
                       ></div>
                     </div>
@@ -514,7 +514,7 @@ export default function ProjectsPage({
                       <Badge variant="outline">available</Badge>
                       <button
                         onClick={() => handleEdit(project)}
-                        className="p-1 text-gray-500 hover:text-blue-600 transition-colors"
+                        className="p-1 text-gray-500 hover:text-brand-primary transition-colors"
                         title="Edit project"
                       >
                         <Edit2 className="w-4 h-4" />
@@ -574,7 +574,7 @@ export default function ProjectsPage({
                       <Badge variant="outline">waiting</Badge>
                       <button
                         onClick={() => handleEdit(project)}
-                        className="p-1 text-gray-500 hover:text-blue-600 transition-colors"
+                        className="p-1 text-gray-500 hover:text-brand-primary transition-colors"
                         title="Edit project"
                       >
                         <Edit2 className="w-4 h-4" />
@@ -645,7 +645,7 @@ export default function ProjectsPage({
                         )}
                       <button
                         onClick={() => handleEdit(project)}
-                        className="p-1 text-gray-500 hover:text-blue-600 transition-colors"
+                        className="p-1 text-gray-500 hover:text-brand-primary transition-colors"
                         title="Edit project"
                       >
                         <Edit2 className="w-4 h-4" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -65,6 +65,7 @@ export default {
           orange: '#FBAD3F',
           'orange-dark': '#E89A2F',
           burgundy: '#A31C41',
+          gold: '#B8860B',
           'light-blue': '#47B3CB',
           'dark-gray': 'hsl(24 5% 38%)' /* #605251 */,
           'light-gray': 'hsl(0 0% 82%)' /* #D1D3D4 */,


### PR DESCRIPTION
## Summary
- replace hard-coded background colors with brand tokens
- add `gold` brand color and apply across components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c73d4e14b08326b7378b6095f63539