### PR TITLE
feat: add theme provider and design tokens

### DIFF
--- a/client/src/components/analytics-dashboard.tsx
+++ b/client/src/components/analytics-dashboard.tsx
@@ -271,12 +271,12 @@ export default function AnalyticsDashboard() {
                 <LineChart data={analyticsData.trendData}>
                   <CartesianGrid
                     strokeDasharray="3 3"
-                    stroke="#236383"
+                    stroke="var(--tsp-primary)"
                     opacity={0.2}
                   />
-                  <XAxis dataKey="month" stroke="#236383" fontSize={12} />
+                  <XAxis dataKey="month" stroke="var(--tsp-primary)" fontSize={12} />
                   <YAxis
-                    stroke="#236383"
+                    stroke="var(--tsp-primary)"
                     fontSize={12}
                     tickFormatter={(value) => `${(value / 1000).toFixed(0)}K`}
                   />
@@ -285,20 +285,20 @@ export default function AnalyticsDashboard() {
                       `${Number(value).toLocaleString()} sandwiches`,
                       'Total',
                     ]}
-                    labelStyle={{ color: '#236383' }}
+                    labelStyle={{ color: 'var(--tsp-primary)' }}
                     contentStyle={{
                       backgroundColor: 'white',
-                      border: '1px solid #236383',
+                      border: '1px solid var(--tsp-primary)',
                       borderRadius: '8px',
                     }}
                   />
                   <Line
                     type="monotone"
                     dataKey="sandwiches"
-                    stroke="#236383"
+                    stroke="var(--tsp-primary)"
                     strokeWidth={3}
-                    dot={{ fill: '#236383', strokeWidth: 2, r: 4 }}
-                    activeDot={{ r: 6, fill: '#FBAD3F' }}
+                    dot={{ fill: 'var(--tsp-primary)', strokeWidth: 2, r: 4 }}
+                    activeDot={{ r: 6, fill: 'var(--tsp-secondary)' }}
                   />
                 </LineChart>
               </ResponsiveContainer>

--- a/client/src/components/modern-dashboard/custom-svg-icons.tsx
+++ b/client/src/components/modern-dashboard/custom-svg-icons.tsx
@@ -11,7 +11,10 @@ export function SandwichStackIcon({
     <svg className={className} viewBox="0 0 24 24" fill="none">
       <defs>
         <linearGradient id="sandwichGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" style={{ stopColor: '#FBAD3F', stopOpacity: 1 }} />
+          <stop
+            offset="0%"
+            style={{ stopColor: 'var(--tsp-secondary)', stopOpacity: 1 }}
+          />
           <stop
             offset="100%"
             style={{ stopColor: '#f09f2b', stopOpacity: 1 }}
@@ -43,7 +46,10 @@ export function GrowthTrendIcon({
     <svg className={className} viewBox="0 0 24 24" fill="none">
       <defs>
         <linearGradient id="growthGrad" x1="0%" y1="100%" x2="100%" y2="0%">
-          <stop offset="0%" style={{ stopColor: '#236383', stopOpacity: 1 }} />
+          <stop
+            offset="0%"
+            style={{ stopColor: 'var(--tsp-primary)', stopOpacity: 1 }}
+          />
           <stop
             offset="100%"
             style={{ stopColor: '#47B3CB', stopOpacity: 1 }}
@@ -64,9 +70,9 @@ export function GrowthTrendIcon({
         strokeLinecap="round"
         strokeLinejoin="round"
       />
-      <circle cx="9" cy="11" r="2" fill="#FBAD3F" opacity="0.8" />
-      <circle cx="15" cy="5" r="2" fill="#FBAD3F" opacity="0.8" />
-      <circle cx="21" cy="3" r="2" fill="#FBAD3F" opacity="0.8" />
+      <circle cx="9" cy="11" r="2" fill="var(--tsp-secondary)" opacity="0.8" />
+      <circle cx="15" cy="5" r="2" fill="var(--tsp-secondary)" opacity="0.8" />
+      <circle cx="21" cy="3" r="2" fill="var(--tsp-secondary)" opacity="0.8" />
     </svg>
   );
 }
@@ -79,11 +85,17 @@ export function CommunityIcon({
     <svg className={className} viewBox="0 0 24 24" fill="none">
       <defs>
         <linearGradient id="communityGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" style={{ stopColor: '#A31C41', stopOpacity: 1 }} />
-          <stop offset="50%" style={{ stopColor: '#FBAD3F', stopOpacity: 1 }} />
+          <stop
+            offset="0%"
+            style={{ stopColor: 'var(--tsp-accent)', stopOpacity: 1 }}
+          />
+          <stop
+            offset="50%"
+            style={{ stopColor: 'var(--tsp-secondary)', stopOpacity: 1 }}
+          />
           <stop
             offset="100%"
-            style={{ stopColor: '#236383', stopOpacity: 1 }}
+            style={{ stopColor: 'var(--tsp-primary)', stopOpacity: 1 }}
           />
         </linearGradient>
       </defs>
@@ -118,14 +130,17 @@ export function TargetIcon({
     <svg className={className} viewBox="0 0 24 24" fill="none">
       <defs>
         <radialGradient id="targetGrad" cx="50%" cy="50%" r="50%">
-          <stop offset="0%" style={{ stopColor: '#FBAD3F', stopOpacity: 1 }} />
+          <stop
+            offset="0%"
+            style={{ stopColor: 'var(--tsp-secondary)', stopOpacity: 1 }}
+          />
           <stop
             offset="70%"
-            style={{ stopColor: '#236383', stopOpacity: 0.8 }}
+            style={{ stopColor: 'var(--tsp-primary)', stopOpacity: 0.8 }}
           />
           <stop
             offset="100%"
-            style={{ stopColor: '#A31C41', stopOpacity: 0.6 }}
+            style={{ stopColor: 'var(--tsp-accent)', stopOpacity: 0.6 }}
           />
         </radialGradient>
       </defs>
@@ -163,7 +178,10 @@ export function SparkleIcon({
     <svg className={className} viewBox="0 0 24 24" fill="none">
       <defs>
         <linearGradient id="sparkleGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" style={{ stopColor: '#FBAD3F', stopOpacity: 1 }} />
+          <stop
+            offset="0%"
+            style={{ stopColor: 'var(--tsp-secondary)', stopOpacity: 1 }}
+          />
           <stop offset="50%" style={{ stopColor: '#fbbf24', stopOpacity: 1 }} />
           <stop
             offset="100%"
@@ -179,7 +197,7 @@ export function SparkleIcon({
         cx="18"
         cy="6"
         r="1.5"
-        fill="#FBAD3F"
+        fill="var(--tsp-secondary)"
         opacity="0.8"
         className="animate-pulse"
       />
@@ -187,7 +205,7 @@ export function SparkleIcon({
         cx="6"
         cy="18"
         r="1"
-        fill="#FBAD3F"
+        fill="var(--tsp-secondary)"
         opacity="0.6"
         className="animate-pulse"
       />
@@ -195,7 +213,7 @@ export function SparkleIcon({
         cx="20"
         cy="16"
         r="1"
-        fill="#FBAD3F"
+        fill="var(--tsp-secondary)"
         opacity="0.7"
         className="animate-pulse"
       />

--- a/client/src/context/theme-provider.tsx
+++ b/client/src/context/theme-provider.tsx
@@ -1,0 +1,71 @@
+import React, { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+// Theme definitions mapping CSS variables to values
+const themes: Record<Theme, Record<string, string>> = {
+  light: {
+    '--primary': '197 53% 32%',
+    '--primary-hover': '197 53% 28%',
+    '--tsp-primary': '#236383',
+    '--tsp-secondary': '#FBAD3F',
+    '--tsp-accent': '#A31C41',
+    '--tsp-muted': '#007E8C',
+    '--tsp-teal': '#236383',
+    '--tsp-teal-light': '#f0f9ff',
+    '--tsp-teal-hover': '#1a4e66',
+    '--tsp-teal-dark': '#004F59',
+  },
+  dark: {
+    '--primary': '210 40% 98%',
+    '--primary-hover': '210 40% 90%',
+    '--tsp-primary': '#47B3CB',
+    '--tsp-secondary': '#E89A2F',
+    '--tsp-accent': '#FB6C85',
+    '--tsp-muted': '#006B75',
+    '--tsp-teal': '#47B3CB',
+    '--tsp-teal-light': '#1a4e66',
+    '--tsp-teal-hover': '#63cce2',
+    '--tsp-teal-dark': '#005f6b',
+  },
+};
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>('light');
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const vars = themes[theme];
+    Object.entries(vars).forEach(([key, value]) => {
+      root.style.setProperty(key, value);
+    });
+  }, [theme]);
+
+  const setTheme = (newTheme: Theme) => setThemeState(newTheme);
+  const toggleTheme = () => setThemeState((t) => (t === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return ctx;
+}
+
+export const themeValues = themes;
+

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';
+import { ThemeProvider } from '@/context/theme-provider';
 
-createRoot(document.getElementById('root')!).render(<App />);
+createRoot(document.getElementById('root')!).render(
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>
+);

--- a/client/src/styles/base.css
+++ b/client/src/styles/base.css
@@ -38,7 +38,7 @@ body {
     --card-foreground: 24 5% 38%; /* #605251 */
     --border: 0 0% 90%; /* Light border */
     --input: 0 0% 96%; /* Light input background */
-    --primary: 197 53% 32%; /* #236383 - TSP Primary Blue */
+    /* --primary moved to ThemeProvider */
     --primary-foreground: 0 0% 100%; /* #FFFFFF */
     --secondary: 27 92% 62%; /* #FBAD3F - Orange */
     --secondary-foreground: 24 5% 38%; /* #605251 */
@@ -51,10 +51,7 @@ body {
     --gradient-from: 210 100% 98%;
     --gradient-via: 220 50% 96%;
     --gradient-to: 230 25% 94%;
-    --tsp-primary: #236383;
-    --tsp-secondary: #FBAD3F;
-    --tsp-accent: #A31C41;
-    --tsp-muted: #007E8C;
+    /* TSP brand variables moved to ThemeProvider */
   }
 
   .dark {
@@ -64,7 +61,7 @@ body {
     --card-foreground: 210 40% 98%;
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
+    /* --primary moved to ThemeProvider */
     --primary-foreground: 222.2 47.4% 11.2%;
     --secondary: 217.2 32.6% 17.5%;
     --secondary-foreground: 210 40% 98%;

--- a/client/src/styles/components.css
+++ b/client/src/styles/components.css
@@ -7,19 +7,21 @@
   }
 
   [role="tab"] {
-    @apply bg-white text-[#236383] border-0 shadow-none;
+    @apply bg-white border-0 shadow-none;
+    color: var(--tsp-teal);
   }
 
   [role="tab"][data-state="active"] {
-    @apply bg-[#236383] text-white border-0 shadow-none;
+    @apply text-white border-0 shadow-none;
+    background-color: var(--tsp-teal);
   }
 
   [role="tab"]:hover {
-    @apply bg-[#f0f9ff];
+    background-color: var(--tsp-teal-light);
   }
 
   [role="tab"][data-state="active"]:hover {
-    @apply bg-[#1a4e66];
+    background-color: var(--tsp-teal-hover);
   }
 
   /* Professional Button Styling */
@@ -175,7 +177,7 @@
 
   .badge-completed {
     @apply px-2 py-1 text-xs font-medium rounded-full;
-    background-color: #FBAD3F;
+    background-color: var(--tsp-secondary);
     color: #8B4513;
   }
 


### PR DESCRIPTION
## Summary
- implement ThemeProvider with light/dark token sets
- wrap app root with ThemeProvider
- move brand CSS variables to provider and refactor components to use tokens

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c741e15a048326aea96a8e5b27f582