### PR TITLE
Include waiting status in project tabled bucket

### DIFF
--- a/client/src/components/projects-v2/context/ProjectContext.tsx
+++ b/client/src/components/projects-v2/context/ProjectContext.tsx
@@ -2,6 +2,8 @@ import React, { createContext, useContext, useState, useEffect, ReactNode } from
 import { Project, InsertProject } from '@shared/schema';
 import { useQuery } from '@tanstack/react-query';
 
+const TABLED_STATUSES: Array<Project['status']> = ['tabled', 'waiting'];
+
 interface ProjectContextValue {
   // Projects data
   projects: Project[];
@@ -39,7 +41,7 @@ interface ProjectContextValue {
 
   // Stats
   projectStats: {
-    tabled: number;
+    tabledAndWaiting: number;
     inProgress: number;
     completed: number;
     archived: number;
@@ -124,8 +126,10 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({ children }) =>
       filtered = activeProjects;
     } else if (status === 'archived') {
       filtered = archivedProjects;
+    } else if (status === 'tabled') {
+      filtered = activeProjects.filter((p) => TABLED_STATUSES.includes(p.status));
     } else {
-      filtered = activeProjects.filter(p => p.status === status);
+      filtered = activeProjects.filter((p) => p.status === status);
     }
 
     // Apply type filter
@@ -159,12 +163,12 @@ export const ProjectProvider: React.FC<ProjectProviderProps> = ({ children }) =>
 
   // Calculate stats
   const projectStats = {
-    tabled: activeProjects.filter(p => p.status === 'tabled').length,
-    inProgress: activeProjects.filter(p => p.status === 'in_progress').length,
-    completed: activeProjects.filter(p => p.status === 'completed').length,
+    tabledAndWaiting: activeProjects.filter((p) => TABLED_STATUSES.includes(p.status)).length,
+    inProgress: activeProjects.filter((p) => p.status === 'in_progress').length,
+    completed: activeProjects.filter((p) => p.status === 'completed').length,
     archived: archivedProjects.length,
-    meeting: activeProjects.filter(p => p.googleSheetRowId).length,
-    internal: activeProjects.filter(p => !p.googleSheetRowId).length,
+    meeting: activeProjects.filter((p) => p.googleSheetRowId).length,
+    internal: activeProjects.filter((p) => !p.googleSheetRowId).length,
   };
 
   // Reset new project form

--- a/client/src/components/projects-v2/index.tsx
+++ b/client/src/components/projects-v2/index.tsx
@@ -152,7 +152,7 @@ const ProjectsManagementContent: React.FC = () => {
             }`}
           >
             <Circle className="w-4 h-4 mr-2" />
-            Tabled ({projectStats.tabled})
+            Tabled & Waiting ({projectStats.tabledAndWaiting})
           </Button>
 
           <Button
@@ -202,7 +202,9 @@ const ProjectsManagementContent: React.FC = () => {
         emptyMessage={
           searchQuery
             ? `No projects found matching "${searchQuery}"`
-            : `No ${(activeTab || '').replace('_', ' ')} projects`
+            : activeTab === 'tabled'
+              ? 'No tabled or waiting projects'
+              : `No ${(activeTab || '').replace('_', ' ')} projects`
         }
       />
 


### PR DESCRIPTION
## Summary
- treat `waiting` projects as part of the Projects Management "Tabled" bucket in context filtering and stats
- refresh the status tab label and empty state copy to clarify the combined "Tabled & Waiting" view

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated driver card and backup route files)*

------
https://chatgpt.com/codex/tasks/task_e_68d22dd8aacc8326863dc733add6c7b5