### PR TITLE
Fix local parsing for collection dates in analytics

### DIFF
--- a/client/src/components/analytics-dashboard.tsx
+++ b/client/src/components/analytics-dashboard.tsx
@@ -27,6 +27,7 @@ import {
   calculateTotalSandwiches,
   calculateActualWeeklyAverage,
   getRecordWeek,
+  parseCollectionDate,
 } from '@/lib/analytics-utils';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -148,15 +149,14 @@ export default function AnalyticsDashboard() {
           console.log(`⚠️ Skipping collection ${index}: No date`);
           return;
         }
-        
-        // Extract YYYY-MM from date string (bulletproof parsing)
-        const monthMatch = dateStr.match(/^(\d{4})-(\d{2})/);
-        if (!monthMatch) {
+
+        const parsedDate = parseCollectionDate(dateStr);
+        if (Number.isNaN(parsedDate.getTime())) {
           console.log(`⚠️ Skipping collection ${index}: Invalid date format: ${dateStr}`);
           return;
         }
-        
-        const monthKey = `${monthMatch[1]}-${monthMatch[2]}`;
+
+        const monthKey = `${parsedDate.getFullYear()}-${String(parsedDate.getMonth() + 1).padStart(2, '0')}`;
         
         // Calculate total sandwiches for this collection
         const individual = Number(collection.individualSandwiches || 0);

--- a/client/src/lib/analytics-utils.ts
+++ b/client/src/lib/analytics-utils.ts
@@ -1,6 +1,21 @@
 import type { SandwichCollection } from '@shared/schema';
 
 /**
+ * Parse a collection date string and ensure YYYY-MM-DD values are treated as local time.
+ */
+export function parseCollectionDate(dateStr: string): Date {
+  if (!dateStr) {
+    return new Date(NaN);
+  }
+
+  if (/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+    return new Date(`${dateStr}T00:00:00`);
+  }
+
+  return new Date(dateStr);
+}
+
+/**
  * Standardized group sandwiches calculation for consistent analytics across all components.
  * This function ensures all frontend components use the same logic as the backend stats endpoint.
  *
@@ -86,7 +101,7 @@ export function calculateWeeklyData(collections: SandwichCollection[]): Array<{
   collections.forEach((collection) => {
     if (!collection.collectionDate) return;
 
-    const date = new Date(collection.collectionDate);
+    const date = parseCollectionDate(collection.collectionDate);
 
     // Calculate week start (Monday)
     const weekStart = new Date(date);


### PR DESCRIPTION
## Summary
- add a shared `parseCollectionDate` helper that treats YYYY-MM-DD values as local midnights and reuses it in analytics utilities
- update host, monthly comparison, impact, and analytics dashboards to rely on the helper for consistent monthly and weekly totals across time zones

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d230f154e08326a5508dd312c32c86