### PR TITLE
Fix project owner edit permissions

### DIFF
--- a/client/src/components/projects-v2/dialogs/CreateProjectDialog.tsx
+++ b/client/src/components/projects-v2/dialogs/CreateProjectDialog.tsx
@@ -151,8 +151,15 @@ export const CreateProjectDialog: React.FC = () => {
               <ProjectAssigneeSelector
                 label="Project Owner"
                 value={newProject.assigneeName || ''}
-                onChange={(assigneeName) => {
-                  setNewProject({ ...newProject, assigneeName });
+                onChange={(assigneeName, userIds) => {
+                  setNewProject({
+                    ...newProject,
+                    assigneeName,
+                    assigneeIds:
+                      userIds && userIds.length > 0
+                        ? userIds
+                        : [],
+                  });
                 }}
                 placeholder="Select or enter project owner"
                 multiple={false}

--- a/client/src/components/projects-v2/dialogs/EditProjectDialog.tsx
+++ b/client/src/components/projects-v2/dialogs/EditProjectDialog.tsx
@@ -36,6 +36,12 @@ export const EditProjectDialog: React.FC = () => {
   // Populate form when editing project changes
   useEffect(() => {
     if (editingProject) {
+      const derivedAssigneeIds = Array.isArray(editingProject.assigneeIds)
+        ? editingProject.assigneeIds.map((id) => id?.toString())
+        : editingProject.assigneeId !== null && editingProject.assigneeId !== undefined
+          ? [editingProject.assigneeId.toString()]
+          : [];
+
       setFormData({
         title: editingProject.title || '',
         description: editingProject.description || '',
@@ -43,6 +49,7 @@ export const EditProjectDialog: React.FC = () => {
         priority: editingProject.priority || 'medium',
         category: editingProject.category || 'technology',
         assigneeName: editingProject.assigneeName || '',
+        assigneeIds: derivedAssigneeIds,
         supportPeople: editingProject.supportPeople || '',
         dueDate: editingProject.dueDate ? editingProject.dueDate.split('T')[0] : '',
         estimatedHours: editingProject.estimatedHours || 0,
@@ -196,8 +203,15 @@ export const EditProjectDialog: React.FC = () => {
               <ProjectAssigneeSelector
                 label="Project Owner"
                 value={formData.assigneeName || ''}
-                onChange={(assigneeName) => {
-                  setFormData({ ...formData, assigneeName });
+                onChange={(assigneeName, userIds) => {
+                  setFormData({
+                    ...formData,
+                    assigneeName,
+                    assigneeIds:
+                      userIds && userIds.length > 0
+                        ? userIds
+                        : [],
+                  });
                 }}
                 placeholder="Select or enter project owner"
                 multiple={false}


### PR DESCRIPTION
## Summary
- update the project card edit gating to check owner IDs and normalized names instead of emails
- persist project owner assignee IDs when creating or editing a project so the permission check has reliable data

## Testing
- npm run test -- --runTestsByPath test/unified-permissions.test.js *(fails: Neon database not reachable in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c1d865648326a28f6836a4af0991