### PR TITLE
Gate Projects V2 user queries to assignment data

### DIFF
--- a/client/src/components/projects-v2/hooks/useProjectQueries.ts
+++ b/client/src/components/projects-v2/hooks/useProjectQueries.ts
@@ -1,38 +1,88 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { User } from '@shared/schema';
+import { useAuth } from '@/hooks/useAuth';
+import { hasPermission, PERMISSIONS } from '@shared/auth-utils';
+
+type ProjectUser = Pick<
+  User,
+  'id' | 'email' | 'firstName' | 'lastName' | 'displayName'
+> &
+  Partial<User>;
 
 export const useProjectQueries = () => {
-  // Fetch users for assignee selection and display
-  const { data: users = [], isLoading: usersLoading } = useQuery<User[]>({
+  const { user: currentUser } = useAuth();
+  const canManageUsers = hasPermission(currentUser, PERMISSIONS.USERS_EDIT);
+
+  // Fetch users for assignee selection and display (admin-only)
+  const {
+    data: adminUsers = [],
+    isLoading: adminUsersLoading,
+  } = useQuery<User[]>({
     queryKey: ['/api/users'],
     staleTime: 5 * 60 * 1000, // Cache for 5 minutes
+    enabled: canManageUsers,
   });
 
   // Fetch users specifically for assignments (might have different permissions)
-  const { data: usersForAssignments = [], isLoading: assignmentsLoading } = useQuery<User[]>({
+  const {
+    data: usersForAssignments = [],
+    isLoading: assignmentsLoading,
+  } = useQuery<ProjectUser[]>({
     queryKey: ['/api/users/for-assignments'],
     staleTime: 5 * 60 * 1000,
   });
 
+  const userLookup = useMemo(() => {
+    const map = new Map<string, ProjectUser>();
+
+    usersForAssignments.forEach((assignmentUser) => {
+      if (!assignmentUser?.id) return;
+      map.set(assignmentUser.id.toString(), assignmentUser);
+    });
+
+    if (canManageUsers) {
+      adminUsers.forEach((adminUser) => {
+        if (!adminUser?.id) return;
+        map.set(adminUser.id.toString(), adminUser);
+      });
+    }
+
+    return map;
+  }, [usersForAssignments, adminUsers, canManageUsers]);
+
   // Helper function to get user by ID
-  const getUserById = (userId: string | number): User | undefined => {
-    return users.find((u) => u.id === userId?.toString());
+  const getUserById = (
+    userId: string | number | null | undefined
+  ): ProjectUser | undefined => {
+    if (userId === null || userId === undefined) return undefined;
+    return userLookup.get(userId.toString());
   };
 
   // Helper function to get user display name
   const getUserDisplayName = (userId: string | number): string => {
     const user = getUserById(userId);
-    if (!user) return 'Unknown';
+    if (!user) {
+      return userId ? userId.toString() : 'Unknown';
+    }
+
+    if (user.displayName) {
+      return user.displayName;
+    }
 
     const name = `${user.firstName || ''} ${user.lastName || ''}`.trim();
-    return name || user.email || 'Unknown';
+    if (name) return name;
+
+    if (user.email) return user.email;
+
+    return `User ${user.id}`;
   };
 
   // Helper function to get multiple users by IDs
-  const getUsersByIds = (userIds: (string | number)[]): User[] => {
+  const getUsersByIds = (userIds: (string | number)[]): ProjectUser[] => {
     return userIds
       .map(id => getUserById(id))
-      .filter((user): user is User => user !== undefined);
+      .filter((user): user is ProjectUser => user !== undefined);
   };
 
   // Parse comma-separated names or IDs
@@ -42,9 +92,9 @@ export const useProjectQueries = () => {
   };
 
   return {
-    users,
+    users: canManageUsers ? adminUsers : usersForAssignments,
     usersForAssignments,
-    usersLoading,
+    usersLoading: canManageUsers ? adminUsersLoading : assignmentsLoading,
     assignmentsLoading,
     getUserById,
     getUserDisplayName,


### PR DESCRIPTION
## Summary
- only request /api/users when the viewer has USERS_EDIT and rely on the assignment list otherwise
- build a shared user lookup from the assignment dataset so display helpers work without admin data
- improve display name fallback logic so non-admins still see meaningful owner/supporter labels

## Testing
- npm run check *(fails: existing TypeScript syntax errors in unrelated driver-card and routes_backup files)*

------
https://chatgpt.com/codex/tasks/task_e_68d6dd2023688326b616e691cbcfe9d9