### PR TITLE
Ensure project assignee IDs persist across UI flows

### DIFF
--- a/client/src/components/enhanced-meeting-dashboard.tsx
+++ b/client/src/components/enhanced-meeting-dashboard.tsx
@@ -125,7 +125,9 @@ export default function EnhancedMeetingDashboard() {
   const [showEditOwnerDialog, setShowEditOwnerDialog] = useState(false);
   const [showAddTaskDialog, setShowAddTaskDialog] = useState(false);
   const [editSupportPeople, setEditSupportPeople] = useState<string>('');
+  const [editSupportPeopleIds, setEditSupportPeopleIds] = useState<string[]>([]);
   const [editProjectOwner, setEditProjectOwner] = useState<string>('');
+  const [editProjectOwnerIds, setEditProjectOwnerIds] = useState<string[]>([]);
   const [supportPeopleList, setSupportPeopleList] = useState<
     Array<{
       id?: string;
@@ -769,8 +771,12 @@ export default function EnhancedMeetingDashboard() {
           setEditingProject={setEditingProject}
           editSupportPeople={editSupportPeople}
           setEditSupportPeople={setEditSupportPeople}
+          editSupportPeopleIds={editSupportPeopleIds}
+          setEditSupportPeopleIds={setEditSupportPeopleIds}
           editProjectOwner={editProjectOwner}
           setEditProjectOwner={setEditProjectOwner}
+          editProjectOwnerIds={editProjectOwnerIds}
+          setEditProjectOwnerIds={setEditProjectOwnerIds}
           newTaskTitle={newTaskTitle}
           setNewTaskTitle={setNewTaskTitle}
           newTaskDescription={newTaskDescription}
@@ -825,12 +831,15 @@ export default function EnhancedMeetingDashboard() {
           </DialogHeader>
           <ProjectAssigneeSelector
             value={editSupportPeople}
-            onChange={(value) => {
+            onChange={(value, userIds) => {
               setEditSupportPeople(value);
+              const normalizedIds = userIds?.length ? userIds : [];
+              setEditSupportPeopleIds(normalizedIds);
               if (editingProject) {
                 updateProjectSupportPeopleMutation.mutate({
                   projectId: editingProject,
                   supportPeople: value,
+                  supportPeopleIds: normalizedIds,
                 });
               }
             }}
@@ -851,12 +860,15 @@ export default function EnhancedMeetingDashboard() {
           </DialogHeader>
           <ProjectAssigneeSelector
             value={editProjectOwner}
-            onChange={(value) => {
+            onChange={(value, userIds) => {
               setEditProjectOwner(value);
+              const normalizedIds = userIds?.length ? userIds : [];
+              setEditProjectOwnerIds(normalizedIds);
               if (editingProject) {
                 updateProjectOwnerMutation.mutate({
                   projectId: editingProject,
                   assigneeName: value,
+                  assigneeIds: normalizedIds,
                 });
               }
               setShowEditOwnerDialog(false);

--- a/client/src/components/meetings/dashboard/hooks/useProjects.ts
+++ b/client/src/components/meetings/dashboard/hooks/useProjects.ts
@@ -15,7 +15,9 @@ export interface Project {
   meetingDiscussionPoints?: string;
   meetingDecisionItems?: string;
   supportPeople?: string;
+  supportPeopleIds?: string[];
   assigneeName?: string;
+  assigneeIds?: string[];
   category?: string;
   dueDate?: string;
   lastDiscussedDate?: string;
@@ -40,7 +42,9 @@ export interface ProjectUpdateData {
   reviewInNextMeeting?: boolean;
   priority?: string;
   supportPeople?: string;
+  supportPeopleIds?: string[];
   assigneeName?: string;
+  assigneeIds?: string[];
 }
 
 // Custom hook for all project-related operations
@@ -191,11 +195,16 @@ export function useProjects(projectAgendaStatus?: Record<number, 'none' | 'agend
     mutationFn: async ({
       projectId,
       supportPeople,
+      supportPeopleIds,
     }: {
       projectId: number;
       supportPeople: string;
+      supportPeopleIds?: string[];
     }) => {
-      return await apiRequest('PATCH', `/api/projects/${projectId}`, { supportPeople });
+      return await apiRequest('PATCH', `/api/projects/${projectId}`, {
+        supportPeople,
+        supportPeopleIds,
+      });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/projects'] });
@@ -218,11 +227,16 @@ export function useProjects(projectAgendaStatus?: Record<number, 'none' | 'agend
     mutationFn: async ({
       projectId,
       assigneeName,
+      assigneeIds,
     }: {
       projectId: number;
       assigneeName: string;
+      assigneeIds?: string[];
     }) => {
-      return await apiRequest('PATCH', `/api/projects/${projectId}`, { assigneeName });
+      return await apiRequest('PATCH', `/api/projects/${projectId}`, {
+        assigneeName,
+        assigneeIds,
+      });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/projects'] });

--- a/client/src/components/meetings/dashboard/tabs/AgendaPlanningTab.tsx
+++ b/client/src/components/meetings/dashboard/tabs/AgendaPlanningTab.tsx
@@ -100,8 +100,12 @@ interface AgendaPlanningTabProps {
   setEditingProject: (projectId: number | null) => void;
   editSupportPeople: string;
   setEditSupportPeople: (people: string) => void;
+  editSupportPeopleIds: string[];
+  setEditSupportPeopleIds: (ids: string[]) => void;
   editProjectOwner: string;
   setEditProjectOwner: (owner: string) => void;
+  editProjectOwnerIds: string[];
+  setEditProjectOwnerIds: (ids: string[]) => void;
   newTaskTitle: string;
   setNewTaskTitle: (title: string) => void;
   newTaskDescription: string;
@@ -129,7 +133,24 @@ interface AgendaPlanningTabProps {
   handleCreateProject: () => void;
   
   // Mutations - properly typed based on the hooks
-  updateProjectDiscussionMutation: UseMutationResult<unknown, Error, { projectId: number; updates: { meetingDiscussionPoints?: string; meetingDecisionItems?: string; reviewInNextMeeting?: boolean; priority?: string; supportPeople?: string; assigneeName?: string } }, unknown>;
+  updateProjectDiscussionMutation: UseMutationResult<
+    unknown,
+    Error,
+    {
+      projectId: number;
+      updates: {
+        meetingDiscussionPoints?: string;
+        meetingDecisionItems?: string;
+        reviewInNextMeeting?: boolean;
+        priority?: string;
+        supportPeople?: string;
+        supportPeopleIds?: string[];
+        assigneeName?: string;
+        assigneeIds?: string[];
+      };
+    },
+    unknown
+  >;
   updateProjectPriorityMutation: UseMutationResult<unknown, Error, { projectId: number; priority: string }, unknown>;
   createTasksFromNotesMutation: UseMutationResult<unknown, Error, void, unknown>;
   resetAgendaPlanningMutation: UseMutationResult<{ notesProcessed: number; notesCleared: number }, Error, void, unknown>;
@@ -177,8 +198,12 @@ export function AgendaPlanningTab({
   setEditingProject,
   editSupportPeople,
   setEditSupportPeople,
+  editSupportPeopleIds,
+  setEditSupportPeopleIds,
   editProjectOwner,
   setEditProjectOwner,
+  editProjectOwnerIds,
+  setEditProjectOwnerIds,
   newTaskTitle,
   setNewTaskTitle,
   newTaskDescription,
@@ -769,6 +794,11 @@ export function AgendaPlanningTab({
                                         setEditProjectOwner(
                                           project.assigneeName || ''
                                         );
+                                        setEditProjectOwnerIds(
+                                          Array.isArray(project.assigneeIds)
+                                            ? project.assigneeIds.map((id) => id?.toString())
+                                            : []
+                                        );
                                         setShowEditOwnerDialog(true);
                                       }}
                                       data-testid={`button-edit-owner-${project.id}`}
@@ -793,6 +823,11 @@ export function AgendaPlanningTab({
                                         setEditingProject(project.id);
                                         setEditSupportPeople(
                                           project.supportPeople || ''
+                                        );
+                                        setEditSupportPeopleIds(
+                                          Array.isArray(project.supportPeopleIds)
+                                            ? project.supportPeopleIds.map((id) => id?.toString())
+                                            : []
                                         );
                                         setShowEditPeopleDialog(true);
                                       }}
@@ -1288,8 +1323,9 @@ export function AgendaPlanningTab({
           </DialogHeader>
           <ProjectAssigneeSelector
             value={editSupportPeople}
-            onChange={(value) => {
+            onChange={(value, userIds) => {
               setEditSupportPeople(value);
+              setEditSupportPeopleIds(userIds?.length ? userIds : []);
             }}
             label="Support People"
             placeholder="Select or enter support people"
@@ -1319,6 +1355,7 @@ export function AgendaPlanningTab({
                       `/api/projects/${editingProject}`,
                       {
                         supportPeople: editSupportPeople,
+                        supportPeopleIds: editSupportPeopleIds,
                       }
                     );
 
@@ -1367,8 +1404,9 @@ export function AgendaPlanningTab({
           </DialogHeader>
           <ProjectAssigneeSelector
             value={editProjectOwner}
-            onChange={(value) => {
+            onChange={(value, userIds) => {
               setEditProjectOwner(value);
+              setEditProjectOwnerIds(userIds?.length ? userIds : []);
             }}
             label="Project Owner"
             placeholder="Select or enter project owner"
@@ -1394,6 +1432,7 @@ export function AgendaPlanningTab({
                       `/api/projects/${editingProject}`,
                       {
                         assigneeName: editProjectOwner,
+                        assigneeIds: editProjectOwnerIds,
                       }
                     );
 

--- a/client/src/components/projects-v2/cards/ProjectCard.tsx
+++ b/client/src/components/projects-v2/cards/ProjectCard.tsx
@@ -145,7 +145,9 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => {
     const userId = user.id?.toString();
     const normalizedAssigneeIds = Array.isArray(project.assigneeIds)
       ? project.assigneeIds.map((id) => id?.toString())
-      : [];
+      : project.assigneeId !== null && project.assigneeId !== undefined
+        ? [project.assigneeId.toString()]
+        : [];
 
     if (userId && normalizedAssigneeIds.includes(userId)) {
       return true;
@@ -159,7 +161,6 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => {
       const candidateNames = [
         [user.firstName, user.lastName].filter(Boolean).join(' ').trim(),
         user.displayName,
-        user.email,
       ]
         .filter((value): value is string => !!value)
         .map((value) => value.trim().toLowerCase());

--- a/client/src/components/projects-v2/context/ProjectContext.tsx
+++ b/client/src/components/projects-v2/context/ProjectContext.tsx
@@ -73,6 +73,7 @@ const initialNewProject: Partial<InsertProject> = {
   assigneeName: '',
   assigneeIds: [],
   supportPeople: '',
+  supportPeopleIds: [],
   dueDate: '',
   startDate: '',
   estimatedHours: 0,

--- a/client/src/components/projects-v2/dialogs/CreateProjectDialog.tsx
+++ b/client/src/components/projects-v2/dialogs/CreateProjectDialog.tsx
@@ -169,8 +169,15 @@ export const CreateProjectDialog: React.FC = () => {
               <ProjectAssigneeSelector
                 label="Support People"
                 value={newProject.supportPeople || ''}
-                onChange={(supportPeople) => {
-                  setNewProject({ ...newProject, supportPeople });
+                onChange={(supportPeople, userIds) => {
+                  setNewProject({
+                    ...newProject,
+                    supportPeople,
+                    supportPeopleIds:
+                      userIds && userIds.length > 0
+                        ? userIds
+                        : [],
+                  });
                 }}
                 placeholder="Select or enter support people"
                 multiple={true}

--- a/client/src/components/projects-v2/dialogs/EditProjectDialog.tsx
+++ b/client/src/components/projects-v2/dialogs/EditProjectDialog.tsx
@@ -41,6 +41,9 @@ export const EditProjectDialog: React.FC = () => {
         : editingProject.assigneeId !== null && editingProject.assigneeId !== undefined
           ? [editingProject.assigneeId.toString()]
           : [];
+      const derivedSupportPeopleIds = Array.isArray(editingProject.supportPeopleIds)
+        ? editingProject.supportPeopleIds.map((id) => id?.toString())
+        : [];
 
       setFormData({
         title: editingProject.title || '',
@@ -51,6 +54,7 @@ export const EditProjectDialog: React.FC = () => {
         assigneeName: editingProject.assigneeName || '',
         assigneeIds: derivedAssigneeIds,
         supportPeople: editingProject.supportPeople || '',
+        supportPeopleIds: derivedSupportPeopleIds,
         dueDate: editingProject.dueDate ? editingProject.dueDate.split('T')[0] : '',
         estimatedHours: editingProject.estimatedHours || 0,
         actualHours: editingProject.actualHours || 0,
@@ -218,15 +222,22 @@ export const EditProjectDialog: React.FC = () => {
               />
             </div>
             <div className="space-y-2">
-              <ProjectAssigneeSelector
-                label="Support People"
-                value={formData.supportPeople || ''}
-                onChange={(supportPeople) => {
-                  setFormData({ ...formData, supportPeople });
-                }}
-                placeholder="Select or enter support people"
-                multiple={true}
-              />
+            <ProjectAssigneeSelector
+              label="Support People"
+              value={formData.supportPeople || ''}
+              onChange={(supportPeople, userIds) => {
+                setFormData({
+                  ...formData,
+                  supportPeople,
+                  supportPeopleIds:
+                    userIds && userIds.length > 0
+                      ? userIds
+                      : [],
+                });
+              }}
+              placeholder="Select or enter support people"
+              multiple={true}
+            />
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- update project card edit permissions to honor stored assignee IDs and normalized names
- persist assignee and support IDs in project create/edit dialogs and meeting dashboard workflows
- extend meeting hooks and dialogs to send assignee/support identifiers when patching projects

## Testing
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d6e12f34d88326851029a5e3c49c8f