### PR TITLE
Align pending status badge styling

### DIFF
--- a/client/src/components/action-tracking-enhanced.tsx
+++ b/client/src/components/action-tracking-enhanced.tsx
@@ -215,6 +215,8 @@ const ActionTracking = () => {
         return 'bg-blue-100 text-blue-800';
       case 'waiting':
         return 'bg-yellow-100 text-yellow-800';
+      case 'pending':
+        return 'bg-yellow-100 text-yellow-800';
       case 'available':
         return 'bg-purple-100 text-purple-800';
       case 'contact_completed':

--- a/client/src/components/action-tracking.tsx
+++ b/client/src/components/action-tracking.tsx
@@ -116,6 +116,8 @@ const ActionTracking = () => {
         return 'bg-blue-100 text-blue-800';
       case 'waiting':
         return 'bg-yellow-100 text-yellow-800';
+      case 'pending':
+        return 'bg-yellow-100 text-yellow-800';
       case 'available':
         return 'bg-purple-100 text-purple-800';
       case 'contact_completed':

--- a/client/src/pages/project-detail-clean.tsx
+++ b/client/src/pages/project-detail-clean.tsx
@@ -619,6 +619,8 @@ export default function ProjectDetailClean({
         return 'text-purple-600 bg-purple-50 border-purple-200';
       case 'waiting':
         return 'text-gray-600 bg-gray-50 border-gray-200';
+      case 'pending':
+        return 'text-gray-600 bg-gray-50 border-gray-200';
       default:
         return 'text-gray-600 bg-gray-50 border-gray-200';
     }


### PR DESCRIPTION
## Summary
- update action tracking components so pending items share the waiting/tabled badge styling
- ensure project detail view treats pending tasks like other not-started statuses

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6e20d8f1883269c09f2fef133ccc3