### PR TITLE
Align pending task badges with waiting palette

### DIFF
--- a/client/src/components/action-tracking-enhanced.tsx
+++ b/client/src/components/action-tracking-enhanced.tsx
@@ -215,6 +215,8 @@ const ActionTracking = () => {
         return 'bg-blue-100 text-blue-800';
       case 'waiting':
         return 'bg-yellow-100 text-yellow-800';
+      case 'pending':
+        return 'bg-yellow-100 text-yellow-800';
       case 'tabled':
         return 'bg-purple-100 text-purple-800';
       case 'contact_completed':

--- a/client/src/components/action-tracking.tsx
+++ b/client/src/components/action-tracking.tsx
@@ -116,6 +116,8 @@ const ActionTracking = () => {
         return 'bg-blue-100 text-blue-800';
       case 'waiting':
         return 'bg-yellow-100 text-yellow-800';
+      case 'pending':
+        return 'bg-yellow-100 text-yellow-800';
       case 'tabled':
         return 'bg-purple-100 text-purple-800';
       case 'contact_completed':

--- a/client/src/pages/project-detail-clean.tsx
+++ b/client/src/pages/project-detail-clean.tsx
@@ -618,8 +618,8 @@ export default function ProjectDetailClean({
       case 'tabled':
         return 'text-purple-600 bg-purple-50 border-purple-200';
       case 'waiting':
-        return 'text-gray-600 bg-gray-50 border-gray-200';
       case 'pending':
+        // Not-started statuses share the same neutral styling
         return 'text-gray-600 bg-gray-50 border-gray-200';
       default:
         return 'text-gray-600 bg-gray-50 border-gray-200';


### PR DESCRIPTION
## Summary
- style pending badges in both action tracking views with the same palette as waiting/tabled items
- ensure project detail view treats pending tasks with the standard not-started styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6e8f484e88326be4136d41de425f7