### PR TITLE
Replace legacy project status handling

### DIFF
--- a/client/src/pages/project-detail-clean.tsx
+++ b/client/src/pages/project-detail-clean.tsx
@@ -1506,9 +1506,9 @@ export default function ProjectDetailClean({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="available">Available</SelectItem>
-                    <SelectItem value="in_progress">In Progress</SelectItem>
                     <SelectItem value="waiting">Waiting</SelectItem>
+                    <SelectItem value="tabled">Tabled</SelectItem>
+                    <SelectItem value="in_progress">In Progress</SelectItem>
                     <SelectItem value="completed">Completed</SelectItem>
                   </SelectContent>
                 </Select>
@@ -1714,7 +1714,7 @@ export default function ProjectDetailClean({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="available">Available</SelectItem>
+                    <SelectItem value="pending">Pending</SelectItem>
                     <SelectItem value="in_progress">In Progress</SelectItem>
                     <SelectItem value="waiting">Waiting</SelectItem>
                     <SelectItem value="completed">Completed</SelectItem>

--- a/old_files_backup/obsolete_duplicates/projects.tsx
+++ b/old_files_backup/obsolete_duplicates/projects.tsx
@@ -173,7 +173,7 @@ export default function ProjectsPage({
       assigneeNames: newProject.assignedTo || null,
       assigneeIds: JSON.stringify(newProject.assigneeIds || []),
       dueDate: newProject.dueDate || null,
-      status: 'available',
+      status: 'waiting',
       category: 'general',
       progressPercentage: 0,
     };
@@ -208,7 +208,7 @@ export default function ProjectsPage({
   );
   const availableProjects = projects.filter(
     (project: any) =>
-      project.status === 'available' || project.status === 'not_started'
+      project.status === 'waiting' || project.status === 'tabled'
   );
   const waitingProjects = projects.filter(
     (project: any) =>

--- a/server/database-storage.ts
+++ b/server/database-storage.ts
@@ -144,7 +144,12 @@ import {
 } from 'drizzle-orm';
 import type { IStorage } from './storage';
 
-const UNASSIGNED_PROJECT_STATUSES: Array<Project['status']> = ['waiting', 'tabled'];
+const UNASSIGNED_PROJECT_STATUSES: Array<Project['status']> = [
+  'waiting',
+  'tabled',
+  // Support legacy data that may still use the deprecated 'available' status
+  'available' as Project['status'],
+];
 
 export class DatabaseStorage implements IStorage {
   // Users (required for authentication)
@@ -311,6 +316,10 @@ export class DatabaseStorage implements IStorage {
         : '';
     const isAssigning = assigneeWasProvided && normalizedAssigneeName.length > 0;
     const isUnassigning = assigneeWasProvided && normalizedAssigneeName.length === 0;
+
+    if (statusWasProvided && updateData.status === 'available') {
+      updateData.status = currentProject.reviewInNextMeeting ? 'tabled' : 'waiting';
+    }
 
     // If an assignee is set and the project is currently in an unassigned state, move it to in_progress
     if (

--- a/test/regression/projects-patch-permissions.test.ts
+++ b/test/regression/projects-patch-permissions.test.ts
@@ -53,7 +53,7 @@ function createProjectTestContext(overrides: Partial<TestProject> = {}) {
     id: 1,
     title: 'Mock Project',
     description: 'Initial description',
-    status: 'available',
+    status: 'waiting',
     createdBy: 'creator-1',
     assigneeId: 'assigned-owner',
     assigneeIds: ['assigned-owner', 'own-editor'],
@@ -139,7 +139,7 @@ describe('PATCH /api/projects/:id permissions', () => {
     expect(response.status).toBe(403);
 
     const latest = await storage.getProject(1);
-    expect(latest?.status).toBe('available');
+    expect(latest?.status).toBe('waiting');
   });
 
   test('allows assigned user with edit-own permission to update project', async () => {


### PR DESCRIPTION
## Summary
- update the database storage updateProject flow to treat waiting/tabled as the unassigned states and remap legacy "available" updates
- refresh project editing UIs and legacy code to expose the supported waiting/tabled options
- align regression tests with the new default status expectations

## Testing
- npm test -- --runTestsByPath test/regression/projects-patch-permissions.test.ts *(fails: NeonDbError: Error connecting to database: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68d6eefd9c608326b452dff7a5ed52fe