### PR TITLE
Add meetings CRUD handlers to modular router

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -8,7 +8,7 @@ import usersRouter from './users';
 import createProjectRoutes from './projects';
 import tasksRouter from './tasks';
 import collectionsRouter from './collections';
-import meetingsRouter from './meetings';
+import meetingsRouter from './meetings/index';
 import messagingRouter from './messaging';
 import eventRequestsRouter from './event-requests';
 import importCollectionsRouter from './import-collections';


### PR DESCRIPTION
## Summary
- add helper utilities to normalize meeting payloads for the modular meetings router
- expose GET/POST/PATCH/DELETE meeting endpoints alongside type filtering and detail responses
- point the main router to the modular meetings router instead of the legacy implementation

## Testing
- `npm run test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68d70d96a7b08326aa66f89f272750e4