### PR TITLE
Normalize project edit permissions to assignee IDs

### DIFF
--- a/client/src/components/enhanced-meeting-dashboard.tsx
+++ b/client/src/components/enhanced-meeting-dashboard.tsx
@@ -833,7 +833,12 @@ export default function EnhancedMeetingDashboard() {
             value={editSupportPeople}
             onChange={(value, userIds) => {
               setEditSupportPeople(value);
-              const normalizedIds = userIds?.length ? userIds : [];
+              const normalizedIds =
+                userIds && userIds.length > 0
+                  ? userIds
+                      .map((id) => id?.toString())
+                      .filter((id): id is string => Boolean(id))
+                  : [];
               setEditSupportPeopleIds(normalizedIds);
               if (editingProject) {
                 updateProjectSupportPeopleMutation.mutate({
@@ -862,7 +867,12 @@ export default function EnhancedMeetingDashboard() {
             value={editProjectOwner}
             onChange={(value, userIds) => {
               setEditProjectOwner(value);
-              const normalizedIds = userIds?.length ? userIds : [];
+              const normalizedIds =
+                userIds && userIds.length > 0
+                  ? userIds
+                      .map((id) => id?.toString())
+                      .filter((id): id is string => Boolean(id))
+                  : [];
               setEditProjectOwnerIds(normalizedIds);
               if (editingProject) {
                 updateProjectOwnerMutation.mutate({

--- a/client/src/components/meetings/dashboard/dialogs/AddProjectDialog.tsx
+++ b/client/src/components/meetings/dashboard/dialogs/AddProjectDialog.tsx
@@ -86,7 +86,12 @@ export function AddProjectDialog({
                 setNewProjectData({
                   ...newProjectData,
                   assigneeName: value || '',
-                  assigneeIds: userIds || [],
+                  assigneeIds:
+                    userIds && userIds.length > 0
+                      ? userIds
+                          .map((id) => id?.toString())
+                          .filter((id): id is string => Boolean(id))
+                      : [],
                 });
               }}
               placeholder="Select or enter project owner"
@@ -103,7 +108,12 @@ export function AddProjectDialog({
                 setNewProjectData({
                   ...newProjectData,
                   supportPeople: value || '',
-                  supportPeopleIds: userIds || [],
+                  supportPeopleIds:
+                    userIds && userIds.length > 0
+                      ? userIds
+                          .map((id) => id?.toString())
+                          .filter((id): id is string => Boolean(id))
+                      : [],
                 });
               }}
               placeholder="Select or enter support team members"

--- a/client/src/components/meetings/dashboard/tabs/AgendaPlanningTab.tsx
+++ b/client/src/components/meetings/dashboard/tabs/AgendaPlanningTab.tsx
@@ -1325,7 +1325,13 @@ export function AgendaPlanningTab({
             value={editSupportPeople}
             onChange={(value, userIds) => {
               setEditSupportPeople(value);
-              setEditSupportPeopleIds(userIds?.length ? userIds : []);
+              setEditSupportPeopleIds(
+                userIds && userIds.length > 0
+                  ? userIds
+                      .map((id) => id?.toString())
+                      .filter((id): id is string => Boolean(id))
+                  : []
+              );
             }}
             label="Support People"
             placeholder="Select or enter support people"
@@ -1406,7 +1412,13 @@ export function AgendaPlanningTab({
             value={editProjectOwner}
             onChange={(value, userIds) => {
               setEditProjectOwner(value);
-              setEditProjectOwnerIds(userIds?.length ? userIds : []);
+              setEditProjectOwnerIds(
+                userIds && userIds.length > 0
+                  ? userIds
+                      .map((id) => id?.toString())
+                      .filter((id): id is string => Boolean(id))
+                  : []
+              );
             }}
             label="Project Owner"
             placeholder="Select or enter project owner"

--- a/client/src/components/projects-v2/dialogs/CreateProjectDialog.tsx
+++ b/client/src/components/projects-v2/dialogs/CreateProjectDialog.tsx
@@ -158,6 +158,8 @@ export const CreateProjectDialog: React.FC = () => {
                     assigneeIds:
                       userIds && userIds.length > 0
                         ? userIds
+                            .map((id) => id?.toString())
+                            .filter((id): id is string => Boolean(id))
                         : [],
                   });
                 }}
@@ -176,6 +178,8 @@ export const CreateProjectDialog: React.FC = () => {
                     supportPeopleIds:
                       userIds && userIds.length > 0
                         ? userIds
+                            .map((id) => id?.toString())
+                            .filter((id): id is string => Boolean(id))
                         : [],
                   });
                 }}

--- a/client/src/components/projects-v2/dialogs/EditProjectDialog.tsx
+++ b/client/src/components/projects-v2/dialogs/EditProjectDialog.tsx
@@ -214,6 +214,8 @@ export const EditProjectDialog: React.FC = () => {
                     assigneeIds:
                       userIds && userIds.length > 0
                         ? userIds
+                            .map((id) => id?.toString())
+                            .filter((id): id is string => Boolean(id))
                         : [],
                   });
                 }}
@@ -232,6 +234,8 @@ export const EditProjectDialog: React.FC = () => {
                   supportPeopleIds:
                     userIds && userIds.length > 0
                       ? userIds
+                          .map((id) => id?.toString())
+                          .filter((id): id is string => Boolean(id))
                       : [],
                 });
               }}


### PR DESCRIPTION
## Summary
- normalize project editing permissions to rely on stored assignee identifiers while keeping legacy name fallbacks
- persist assignee and support user ID arrays across project create/edit dialogs and meeting dashboard assignment flows
- update project owner kudos controls and dashboard queries to use normalized assignee IDs for consistent access control

## Testing
- not run (npm run lint -- --max-warnings=0 script missing)


------
https://chatgpt.com/codex/tasks/task_e_68d70ba9e27c8326949d215fd77e4018

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize project assignee/support IDs to string arrays across UI, centralize edit/delete checks via shared auth utils, and use assignee IDs for dashboard/kudos and assignment queries.
> 
> - **Backend**
>   - **ID Normalization**: Add `normalizeToString`/`toStringArray` and use them in `/me/dashboard` to match assignments via `assigneeId(s)` and `supportPeopleIds` (camelCase/snake_case) with name fallbacks; validate user ID and improve logging.
>   - **Auth Utils**: Enhance `isProjectOwnerOrAssignee` and `canEditProject` with robust ID/name parsing (`assigneeIds`, `supportPeopleIds`, legacy fields); export centralized `canEditProject`/`canDeleteProject`.
> - **Frontend**
>   - **Assignee ID Handling**: Normalize `assigneeIds`/`supportPeopleIds` to string arrays in `enhanced-meeting-dashboard`, `AgendaPlanningTab`, `AddProjectDialog`, `CreateProjectDialog`, and `EditProjectDialog`.
>   - **ProjectCard**: Replace inline permission logic with shared `canEditProject`/`canDeleteProject`; gate menu actions by permissions; compute `primaryAssigneeId`; update `SendKudosButton` to use `recipientId` and provide project context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41a659685e3508ef8c0eac9a0248525d7bab7492. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->