### PR TITLE
Fix document search when descriptions are missing

### DIFF
--- a/client/src/components/document-management.tsx
+++ b/client/src/components/document-management.tsx
@@ -43,10 +43,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { queryClient } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
 
-interface Document {
+export interface Document {
   id: number;
   title: string;
-  description: string;
+  description?: string | null;
   fileName: string;
   originalName: string;
   filePath: string;
@@ -107,6 +107,23 @@ const PERMISSION_TYPES = [
     description: 'Full access including permissions',
   },
 ];
+
+export function documentMatchesFilters(
+  doc: Document,
+  searchTerm: string,
+  categoryFilter: string
+) {
+  const normalizedSearch = searchTerm.toLowerCase();
+  const matchesSearch =
+    normalizedSearch === '' ||
+    doc.title.toLowerCase().includes(normalizedSearch) ||
+    (doc.description ?? '').toLowerCase().includes(normalizedSearch);
+
+  const matchesCategory =
+    categoryFilter === 'all' || doc.category === categoryFilter;
+
+  return matchesSearch && matchesCategory;
+}
 
 function DocumentUploadDialog({ onSuccess }: { onSuccess: () => void }) {
   const [open, setOpen] = useState(false);
@@ -633,14 +650,9 @@ export default function DocumentManagement() {
     },
   });
 
-  const filteredDocuments = documents.filter((doc: Document) => {
-    const matchesSearch =
-      doc.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      doc.description?.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesCategory =
-      categoryFilter === 'all' || doc.category === categoryFilter;
-    return matchesSearch && matchesCategory;
-  });
+  const filteredDocuments = documents.filter((doc: Document) =>
+    documentMatchesFilters(doc, searchTerm, categoryFilter)
+  );
 
   const getCategoryBadgeVariant = (category: string) => {
     switch (category) {

--- a/test/unit/document-management-filter.test.ts
+++ b/test/unit/document-management-filter.test.ts
@@ -1,0 +1,56 @@
+import { documentMatchesFilters } from '@/components/document-management';
+import type { Document } from '@/components/document-management';
+
+describe('documentMatchesFilters', () => {
+  const baseDocument: Document = {
+    id: 1,
+    title: 'Policy Handbook',
+    description: null,
+    fileName: 'policy.pdf',
+    originalName: 'policy.pdf',
+    filePath: '/uploads/policy.pdf',
+    fileSize: 1024,
+    mimeType: 'application/pdf',
+    category: 'governance',
+    isActive: true,
+    uploadedBy: 'user-1',
+    uploadedByName: 'User One',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-02T00:00:00.000Z',
+  };
+
+  it('matches search term even when description is null', () => {
+    const document = { ...baseDocument, description: null };
+
+    expect(() => documentMatchesFilters(document, 'policy', 'all')).not.toThrow();
+    expect(documentMatchesFilters(document, 'policy', 'all')).toBe(true);
+  });
+
+  it('matches against the description when provided', () => {
+    const document = {
+      ...baseDocument,
+      title: 'Annual Summary',
+      description: 'Comprehensive update for the fiscal year',
+    };
+
+    expect(documentMatchesFilters(document, 'fiscal', 'all')).toBe(true);
+  });
+
+  it('handles undefined descriptions without throwing', () => {
+    const document = { ...baseDocument, description: undefined };
+
+    expect(() => documentMatchesFilters(document, 'policy', 'all')).not.toThrow();
+    expect(documentMatchesFilters(document, 'policy', 'all')).toBe(true);
+  });
+
+  it('respects the category filter', () => {
+    const document = {
+      ...baseDocument,
+      category: 'operations',
+      title: 'Operations Checklist',
+    };
+
+    expect(documentMatchesFilters(document, '', 'operations')).toBe(true);
+    expect(documentMatchesFilters(document, '', 'governance')).toBe(false);
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "noEmit": true,
     "types": ["node", "jest"],
-    "module": "ESNext"
+    "module": "ESNext",
+    "jsx": "react-jsx"
   },
   "include": [
     "client/src/lib/**/*",


### PR DESCRIPTION
## Summary
- guard the document search filter against null or undefined descriptions and reuse a shared helper
- enable ts-jest JSX transforms used by the new helper tests
- add a unit test that covers search/category behaviour with missing descriptions

## Testing
- SKIP_DB_SETUP=true npm test -- document-management-filter.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d71eaddd18832695758f3a7abea118