### PR TITLE
Fix meeting notes router import

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -8,7 +8,7 @@ import usersRouter from './users';
 import createProjectRoutes from './projects';
 import tasksRouter from './tasks';
 import collectionsRouter from './collections';
-import meetingsRouter from './meetings';
+import meetingsRouter from './meetings/index';
 import messagingRouter from './messaging';
 import eventRequestsRouter from './event-requests';
 import importCollectionsRouter from './import-collections';


### PR DESCRIPTION
## Summary
- ensure the modular routes system pulls in the meetings router that contains the notes endpoints
- this allows `/api/meetings/notes` and related handlers to be registered so the meetings agenda tab can load

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d230e49d688326b1d8829a55da3fee

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `meetingsRouter` import from `./meetings` to `./meetings/index` in `server/routes/index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e98f683019dfa707a1fec6b99fa5981e182059e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->