### PR TITLE
Fix host analytics fetch authentication

### DIFF
--- a/client/src/components/host-analytics.tsx
+++ b/client/src/components/host-analytics.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { apiRequest } from '@/lib/queryClient';
 import type { SandwichCollection, Host } from '@shared/schema';
 import { parseCollectionDate } from '@/lib/analytics-utils';
 
@@ -61,11 +62,11 @@ export default function HostAnalytics({
   // Fetch all collections data
   const { data: collectionsResponse, isLoading } = useQuery({
     queryKey: ['/api/sandwich-collections', 'analytics'],
-    queryFn: async () => {
-      const response = await fetch('/api/sandwich-collections?page=1&limit=10000');
-      if (!response.ok) throw new Error('Failed to fetch collections');
-      return response.json();
-    },
+    queryFn: async () =>
+      apiRequest(
+        'GET',
+        '/api/sandwich-collections?page=1&limit=10000'
+      ),
   });
 
   // Fetch hosts list


### PR DESCRIPTION
## Summary
- use the shared apiRequest helper for the host analytics sandwich collection query so credentials are included
- ensure the host analytics tab loads data for authenticated users instead of failing with 401 responses

## Testing
- npm run lint *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d71f1aa4bc8326a0ade024fd1cfe0d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace direct fetch with shared `apiRequest` in `client/src/components/host-analytics.tsx` to ensure authenticated sandwich collections query.
> 
> - **Host Analytics**:
>   - Switch `useQuery` collections fetch to `apiRequest('GET', '/api/sandwich-collections?page=1&limit=10000')` for credentialed requests in `client/src/components/host-analytics.tsx`.
>   - Add import for `apiRequest` from `@/lib/queryClient`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6088be2bc0c4163d149468c152038c16e9c0064c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->