### PR TITLE
Fix document viewer loading state

### DIFF
--- a/client/src/components/DocumentViewer.tsx
+++ b/client/src/components/DocumentViewer.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { FileText, Download, ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
@@ -19,6 +19,17 @@ export function DocumentViewer({
 }: DocumentViewerProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setIsLoading(true);
+    setError(null);
+  }, [fileName, filePath]);
+
+  useEffect(() => {
+    if (fileType !== 'pdf') {
+      setIsLoading(false);
+    }
+  }, [fileType]);
 
   // Extract filename from full path if needed
   const getFileName = (path: string) => {


### PR DESCRIPTION
## Summary
- reset the document viewer loading and error state whenever a new file is selected
- automatically clear the loading overlay for non-PDF files while keeping PDF loading behavior intact

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d71ea451c483268480d0d36d3979e2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reset loading and error state on file changes and automatically clear loading for non-PDFs in `DocumentViewer`.
> 
> - **Component: `client/src/components/DocumentViewer.tsx`**
>   - **State handling**:
>     - Add `useEffect` to reset `isLoading` and `error` when `fileName` or `filePath` changes.
>     - Add `useEffect` to set `isLoading` to `false` when `fileType` is not `pdf`.
>   - **Imports**: replace `useCallback` with `useEffect`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bd23087c6f096f05e3e0faa19ecb195f13dff2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->