### PR TITLE
Fix event request user queries for non-admin access

### DIFF
--- a/client/src/components/event-requests-v2/cards/NewRequestCard.tsx
+++ b/client/src/components/event-requests-v2/cards/NewRequestCard.tsx
@@ -321,7 +321,7 @@ export const NewRequestCard: React.FC<NewRequestCardProps> = ({
 
   // Fetch users data for TSP contact name lookup
   const { data: users = [] } = useQuery<User[]>({
-    queryKey: ['/api/users'],
+    queryKey: ['/api/users/basic'],
     enabled: !!request.tspContact, // Only fetch if there's a TSP contact assigned
   });
 

--- a/client/src/components/event-requests-v2/hooks/useEventQueries.ts
+++ b/client/src/components/event-requests-v2/hooks/useEventQueries.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 
 export const useEventQueries = () => {
-  // Fetch users for resolving user IDs to names
+  // Fetch users for resolving user IDs to names without requiring admin permissions
   const { data: users = [] } = useQuery<any[]>({
-    queryKey: ['/api/users'],
+    queryKey: ['/api/users/basic'],
   });
 
   // Fetch users specifically for assignments


### PR DESCRIPTION
## Summary
- update the event request shared queries to use the basic users endpoint instead of the admin-only listing
- align the new request card user lookup with the basic user endpoint so contact names resolve without permission errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d22aa8fda483268b666657b0c623b7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch user lookup queries to `/api/users/basic` to avoid admin-only access issues and ensure TSP contact/name resolution.
> 
> - **Frontend — Event Requests v2**:
>   - Replace admin-only users query with basic users endpoint:
>     - `client/src/components/event-requests-v2/cards/NewRequestCard.tsx`: `queryKey` from `/api/users` → `/api/users/basic` for TSP contact display.
>     - `client/src/components/event-requests-v2/hooks/useEventQueries.ts`: `queryKey` from `/api/users` → `/api/users/basic` for resolving user IDs to names.
>   - Update inline comment to note non-admin-safe user fetching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed3f43c30f799a2dd67e9d48d57b1b0989eb3b0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->