### PR TITLE
Register missing data management and log routers

### DIFF
--- a/client/src/components/data-management-dashboard.tsx
+++ b/client/src/components/data-management-dashboard.tsx
@@ -44,12 +44,12 @@ export function DataManagementDashboard() {
 
   // Fetch data summary
   const { data: summary, isLoading: summaryLoading } = useQuery({
-    queryKey: ['/api/data/summary'],
+    queryKey: ['/api/data-management/summary'],
   });
 
   // Fetch data integrity status
   const { data: integrityData, isLoading: integrityLoading } = useQuery({
-    queryKey: ['/api/data/integrity/check'],
+    queryKey: ['/api/data-management/integrity/check'],
   });
 
   // Search functionality
@@ -66,7 +66,7 @@ export function DataManagementDashboard() {
   const exportCollectionsMutation = useMutation({
     mutationFn: async () => {
       const response = await fetch(
-        `/api/data/export/collections?format=${exportFormat}`
+        `/api/data-management/export/collections?format=${exportFormat}`
       );
       if (!response.ok) throw new Error('Export failed');
 
@@ -109,7 +109,7 @@ export function DataManagementDashboard() {
   const exportHostsMutation = useMutation({
     mutationFn: async () => {
       const response = await fetch(
-        `/api/data/export/hosts?format=${exportFormat}`
+        `/api/data-management/export/hosts?format=${exportFormat}`
       );
       if (!response.ok) throw new Error('Export failed');
 
@@ -145,15 +145,17 @@ export function DataManagementDashboard() {
   // Bulk operations
   const deduplicateHostsMutation = useMutation({
     mutationFn: () =>
-      apiRequest('/api/data/bulk/deduplicate-hosts', { method: 'POST' }),
+      apiRequest('POST', '/api/data-management/bulk/deduplicate-hosts'),
     onSuccess: (data: any) => {
       toast({
         title: 'Deduplication Complete',
         description: `Removed ${data.deleted || 0} duplicate hosts`,
       });
-      queryClient.invalidateQueries({ queryKey: ['/api/data/summary'] });
       queryClient.invalidateQueries({
-        queryKey: ['/api/data/integrity/check'],
+        queryKey: ['/api/data-management/summary'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['/api/data-management/integrity/check'],
       });
     },
     onError: () => {
@@ -168,13 +170,15 @@ export function DataManagementDashboard() {
   // Import 2023 events mutation
   const import2023EventsMutation = useMutation({
     mutationFn: () =>
-      apiRequest('/api/import-events/import-2023-events', { method: 'POST' }),
+      apiRequest('POST', '/api/import-events/import-2023-events'),
     onSuccess: (data: any) => {
       toast({
         title: 'Import Complete',
         description: `Successfully imported ${data.imported || 0} events from 2023 (skipped ${data.duplicates || 0} duplicates)`,
       });
-      queryClient.invalidateQueries({ queryKey: ['/api/data/summary'] });
+      queryClient.invalidateQueries({
+        queryKey: ['/api/data-management/summary'],
+      });
     },
     onError: (error: any) => {
       toast({
@@ -569,7 +573,7 @@ export function DataManagementDashboard() {
                   onClick={async () => {
                     try {
                       const response = await fetch(
-                        '/api/data/export/full-dataset'
+                        '/api/data-management/export/full-dataset'
                       );
                       if (!response.ok) throw new Error('Export failed');
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -31,8 +31,16 @@ import { wishlistSuggestionsRouter, wishlistActivityRouter } from './wishlist';
 import { streamRoutes } from './stream';
 
 // Import centralized middleware
-import { createStandardMiddleware, createErrorHandler } from '../middleware';
+import {
+  createStandardMiddleware,
+  createErrorHandler,
+  createPublicMiddleware,
+} from '../middleware';
 import type { IStorage } from '../storage';
+import dataManagementRouter from './data-management';
+import { createErrorLogsRoutes } from './error-logs';
+import workLogsRouter from './work-logs';
+import shoutoutsRouter from './shoutouts';
 
 interface RouterDependencies {
   isAuthenticated: any;
@@ -315,6 +323,42 @@ export function createMainRoutes(deps: RouterDependencies) {
     streamRoutes
   );
   router.use('/api/stream', createErrorHandler('stream'));
+
+  // Data management routes for exports, integrity checks, and bulk actions
+  router.use(
+    '/api/data-management',
+    deps.isAuthenticated,
+    ...createStandardMiddleware(),
+    dataManagementRouter
+  );
+  router.use('/api/data-management', createErrorHandler('data-management'));
+
+  // Client error logging endpoint (no auth required so we can capture pre-login issues)
+  const errorLogsRouter = createErrorLogsRoutes(deps.storage);
+  router.use(
+    '/api/error-logs',
+    ...createPublicMiddleware(),
+    errorLogsRouter
+  );
+  router.use('/api/error-logs', createErrorHandler('error-logs'));
+
+  // Work log time tracking endpoints
+  router.use(
+    '/api/work-logs',
+    deps.isAuthenticated,
+    ...createStandardMiddleware(),
+    workLogsRouter
+  );
+  router.use('/api/work-logs', createErrorHandler('work-logs'));
+
+  // Volunteer shoutouts and recognition tools
+  router.use(
+    '/api/shoutouts',
+    deps.isAuthenticated,
+    ...createStandardMiddleware(),
+    shoutoutsRouter
+  );
+  router.use('/api/shoutouts', createErrorHandler('shoutouts'));
 
   return router;
 }

--- a/test/unit/routes-registration.test.ts
+++ b/test/unit/routes-registration.test.ts
@@ -1,0 +1,27 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+describe('Server route registration', () => {
+  let routesContent: string;
+
+  beforeAll(async () => {
+    const routesPath = resolve(__dirname, '../../server/routes/index.ts');
+    routesContent = await readFile(routesPath, 'utf8');
+  });
+
+  test('registers /api/data-management router', () => {
+    expect(routesContent).toContain("router.use(\n    '/api/data-management'");
+  });
+
+  test('registers /api/error-logs router', () => {
+    expect(routesContent).toContain("router.use(\n    '/api/error-logs'");
+  });
+
+  test('registers /api/work-logs router', () => {
+    expect(routesContent).toContain("router.use(\n    '/api/work-logs'");
+  });
+
+  test('registers /api/shoutouts router', () => {
+    expect(routesContent).toContain("router.use(\n    '/api/shoutouts'");
+  });
+});


### PR DESCRIPTION
## Summary
- register the data management, error log, work log, and shoutouts routers in the Express route index with the appropriate middleware
- update the data management dashboard to call the new `/api/data-management` endpoints
- add a lightweight unit test that asserts the new API mounts are present so the regression suite covers these routes

## Testing
- npm test -- --runTestsByPath test/unit/routes-registration.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc25c5585c8326b7b49124d5ea14a4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Registers new API routers and updates the data management dashboard to use `/api/data-management` endpoints, with a unit test validating route mounts.
> 
> - **Backend**:
>   - **Routes Registered**: Mounts `data-management`, `error-logs`, `work-logs`, and `shoutouts` under `/api/...` in `server/routes/index.ts` with appropriate middleware (`createStandardMiddleware`, `createPublicMiddleware`) and error handlers.
> - **Frontend**:
>   - **Endpoint Migration**: In `client/src/components/data-management-dashboard.tsx`, switches data summary, integrity, bulk deduplication, and export calls from `/api/data/*` to `/api/data-management/*` and updates related `queryKey` invalidations; updates full dataset export path.
>   - **API Helper Usage**: Updates `apiRequest` calls to new `(method, path)` signature.
> - **Tests**:
>   - Adds `test/unit/routes-registration.test.ts` to assert registration of `/api/data-management`, `/api/error-logs`, `/api/work-logs`, and `/api/shoutouts` routers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e74290d072919764162bb143b1f84885fcfcd4c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->