### PR TITLE
Refine SMS opt-in and governance colors to use theme tokens

### DIFF
--- a/client/src/components/governance-documents.tsx
+++ b/client/src/components/governance-documents.tsx
@@ -64,13 +64,13 @@ const getFileIcon = (type: string) => {
 const getCategoryColor = (category: string) => {
   switch (category) {
     case 'Legal Foundation':
-      return 'bg-teal-100 text-teal-800';
+      return 'bg-brand-teal/10 text-brand-teal-dark border-brand-teal/40';
     case 'Legal Reference':
-      return 'bg-blue-100 text-blue-800';
+      return 'bg-brand-primary/10 text-brand-primary border-brand-primary/30';
     case 'Tax Status':
-      return 'bg-amber-100 text-amber-800';
+      return 'bg-brand-orange/10 text-brand-orange border-brand-orange/30';
     default:
-      return 'bg-gray-100 text-gray-800';
+      return 'bg-muted text-muted-foreground border-border';
   }
 };
 
@@ -123,10 +123,13 @@ export function GovernanceDocuments() {
           <Button
             key={category}
             variant={selectedCategory === category ? 'default' : 'outline'}
-            className={selectedCategory === category ? 'bg-brand-primary hover:bg-brand-primary-dark text-white border-brand-primary' : 'text-brand-primary border-brand-primary hover:bg-[#f0f9ff]'}
+            className={`${
+              selectedCategory === category
+                ? 'bg-brand-primary hover:bg-brand-primary-dark text-white border-brand-primary'
+                : 'text-brand-primary border-brand-primary hover:bg-brand-primary/10'
+            } text-sm`}
             size="sm"
             onClick={() => setSelectedCategory(category)}
-            className="text-sm"
           >
             {category}
           </Button>
@@ -179,7 +182,7 @@ export function GovernanceDocuments() {
                   size="sm"
                   variant="outline"
                   onClick={() => handlePreview(document)}
-                  className="w-full h-9 text-sm font-medium text-brand-primary border-brand-primary hover:bg-[#f0f9ff]"
+                  className="w-full h-9 text-sm font-medium text-brand-primary border-brand-primary hover:bg-brand-primary/10"
                 >
                   <Eye className="h-4 w-4 mr-2" />
                   Preview

--- a/client/src/pages/sms-opt-in.tsx
+++ b/client/src/pages/sms-opt-in.tsx
@@ -140,7 +140,7 @@ export default function SMSOptInPage() {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin h-8 w-8 border-b-2 border-[#1f7b7b] mx-auto"></div>
+          <div className="animate-spin h-8 w-8 border-b-2 border-brand-primary mx-auto"></div>
           <p className="mt-2 text-gray-600">Loading...</p>
         </div>
       </div>
@@ -186,7 +186,7 @@ export default function SMSOptInPage() {
         <Card>
           <CardHeader className="text-center">
             <div className="flex justify-center mb-4">
-              <div className="bg-[#1f7b7b] p-3 rounded-full">
+              <div className="bg-brand-primary p-3 rounded-full">
                 <MessageSquare className="h-8 w-8 text-white" />
               </div>
             </div>
@@ -241,12 +241,12 @@ export default function SMSOptInPage() {
             ) : (
               // Not opted in - show sign-up form
               <form onSubmit={handleSubmit} className="space-y-6">
-                <div className="bg-blue-50 p-4 rounded-lg">
-                  <h3 className="font-medium text-blue-900 mb-2 flex items-center gap-2">
+                <div className="bg-brand-primary/10 p-4 rounded-lg">
+                  <h3 className="font-medium text-brand-primary-dark mb-2 flex items-center gap-2">
                     <Smartphone className="h-4 w-4" />
                     How SMS Reminders Work
                   </h3>
-                  <ul className="text-sm text-blue-800 space-y-1">
+                  <ul className="text-sm text-brand-primary space-y-1">
                     <li>
                       • Get text reminders when weekly sandwich counts are
                       missing
@@ -312,7 +312,7 @@ export default function SMSOptInPage() {
 
                 <Button
                   type="submit"
-                  className="w-full bg-[#1f7b7b] hover:bg-[#165a5a]"
+                  className="w-full bg-brand-primary hover:bg-brand-primary-dark"
                   disabled={
                     optInMutation.isPending || !consent || !phoneNumber.trim()
                   }


### PR DESCRIPTION
## Summary
- replace hard-coded teal and blue shades in the SMS opt-in page with brand color tokens for consistency
- update governance document filters and badges to rely on semantic Tailwind colors instead of hex and blue variants

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e050dd110c8326b09ebbb68ffe618c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces hex/utility blues/teals with brand theme tokens across governance documents and SMS opt-in, updating badges, buttons, hovers, loader, and info panel styles.
> 
> - **Governance Documents (`client/src/components/governance-documents.tsx`)**:
>   - **Category badges**: swap legacy `bg-*-100 text-*-800` for brand/semantic tokens (e.g., `bg-brand-teal/10 text-brand-teal-dark border-brand-teal/40`, `bg-brand-primary/10`, `bg-brand-orange/10`, `bg-muted text-muted-foreground border-border`).
>   - **Filter buttons**: unify class handling and use brand tokens; outline hover `hover:bg-brand-primary/10`; ensure `text-sm` applied; keep selected state with `bg-brand-primary`/`border-brand-primary`.
>   - **Preview button**: outline hover uses `hover:bg-brand-primary/10` instead of hex.
> - **SMS Opt-in (`client/src/pages/sms-opt-in.tsx`)**:
>   - **Loader**: spinner border uses `border-brand-primary`.
>   - **Header icon**: circle background uses `bg-brand-primary`.
>   - **Info panel**: replace blue variants with brand tints (`bg-brand-primary/10`, `text-brand-primary(-dark)`).
>   - **Submit button**: use `bg-brand-primary hover:bg-brand-primary-dark`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5feb100d3a40c3739e63eed5c4390ad6c80f94eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->