### PR TITLE
Clean up wishlist router middleware setup

### DIFF
--- a/server/routes/wishlist.ts
+++ b/server/routes/wishlist.ts
@@ -8,7 +8,6 @@ import {
   type WishlistSuggestion,
   type InsertWishlistSuggestion 
 } from '../../shared/schema';
-import { createStandardMiddleware } from '../middleware';
 import { logger } from '../middleware/logger';
 
 // Type definitions for authenticated requests
@@ -37,11 +36,8 @@ const updateSuggestionSchema = z.object({
   estimatedCost: z.number().positive().optional(),
 });
 
-// Create suggestions router
+// Create suggestions router (standard middleware is applied by the parent router)
 export const wishlistSuggestionsRouter = Router();
-
-// Apply standard middleware (authentication, logging, etc.)
-wishlistSuggestionsRouter.use(createStandardMiddleware());
 
 // GET /api/wishlist-suggestions - Return all wishlist suggestions from database
 wishlistSuggestionsRouter.get('/', async (req: AuthenticatedRequest, res: Response) => {
@@ -257,11 +253,8 @@ wishlistSuggestionsRouter.delete('/:id', async (req: AuthenticatedRequest, res: 
   }
 });
 
-// Create activity router
+// Create activity router (standard middleware is applied by the parent router)
 export const wishlistActivityRouter = Router();
-
-// Apply standard middleware (authentication, logging, etc.)
-wishlistActivityRouter.use(createStandardMiddleware());
 
 // GET /api/wishlist-activity - Return recent wishlist activity/history
 wishlistActivityRouter.get('/', async (req: AuthenticatedRequest, res: Response) => {


### PR DESCRIPTION
## Summary
- confirm the wishlist router contains the wishlist/suggestion CRUD and activity handlers
- drop the redundant middleware registration inside the wishlist routers since the parent route applies the standard stack
- verified that no references to the deprecated /api/suggestions endpoint remain in the codebase

## Testing
- npm run test:integration -- --runInBand *(hangs waiting for environment, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68e052ab58108326bfa759a5b7097382

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes redundant `createStandardMiddleware` usage from `wishlist` routers, relying on parent router to apply middleware.
> 
> - **Server Routes**:
>   - **Wishlist**:
>     - Remove `createStandardMiddleware` import and `wishlistSuggestionsRouter.use(createStandardMiddleware())`.
>     - Update comment to note middleware is applied by the parent router.
>   - **Activity**:
>     - Remove `wishlistActivityRouter.use(createStandardMiddleware())`.
>     - Update comment to note middleware is applied by the parent router.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b2ac7ff53d597ffc2a55143f4a6512fcd914d5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->