### PR TITLE
Refine weekly monitoring dashboard print styling

### DIFF
--- a/client/src/components/weekly-monitoring-dashboard.tsx
+++ b/client/src/components/weekly-monitoring-dashboard.tsx
@@ -208,6 +208,9 @@ export default function WeeklyMonitoringDashboard() {
       <head>
         <title>Weekly Monitoring Report - ${weekLabel}</title>
         <style>
+          :root {
+            --report-header-background: linear-gradient(135deg, #236383 0%, #007E8C 100%);
+          }
           body {
             font-family: 'Roboto', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
             max-width: 800px;
@@ -220,7 +223,10 @@ export default function WeeklyMonitoringDashboard() {
             text-align: center;
             margin-bottom: 40px;
             padding: 30px;
-            background: linear-gradient(135deg, #236383 0%, #007E8C 100%);
+            background: var(
+              --report-header-background,
+              linear-gradient(135deg, #236383 0%, #007E8C 100%)
+            );
             color: white;
             border-radius: 12px;
             box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
@@ -353,8 +359,13 @@ export default function WeeklyMonitoringDashboard() {
             margin-bottom: 15px;
           }
           @media print {
-            body { background-color: white; padding: 20px; }
-            .header { background: #236383 !important; }
+            body {
+              background-color: white;
+              padding: 20px;
+            }
+            :root {
+              --report-header-background: #236383;
+            }
           }
         </style>
       </head>


### PR DESCRIPTION
## Summary
- replace the print-specific `!important` header override with a CSS variable so the layout adapts for screen and print
- ensure the print stylesheet adjusts the header background via a scoped variable without relying on `!important`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e06a40d98083268b3e37c7fc9ad1ad