### PR TITLE
Map intake checklist answers to structured event columns

### DIFF
--- a/client/src/components/event-requests/IntakeCallDialog.tsx
+++ b/client/src/components/event-requests/IntakeCallDialog.tsx
@@ -84,13 +84,24 @@ const OPERATING_AREAS = [
 ];
 
 // Extract the first integer from an operator's free-text answer.
-// Handles "750", "around 200", "750ish", "approximately 1000".
-// For ranges like "200-300" returns the first number (200) — operator can
-// adjust on the event after intake if needed.
+// Handles common formats: "750", "around 200", "750ish", "1,200" (US-style
+// thousands), "approximately 1000", "200-300" (first number only).
+//
+// Space-separated thousands ("1 200") are deliberately not handled — doing so
+// would also turn two distinct space-separated numbers ("200 300") into
+// 200300, which would silently corrupt counts. With the comma-only rule, the
+// rare "1 200" input parses as 1, which is obviously wrong on the toast.
 function parseNumberFromText(text: string): number | null {
-  const match = text.match(/\d+/);
-  if (!match) return null;
-  const n = parseInt(match[0], 10);
+  // Try thousands-formatted number first (e.g. "1,200" or "1,200,000").
+  const formatted = text.match(/\d{1,3}(?:,\d{3})+/);
+  if (formatted) {
+    const n = parseInt(formatted[0].replace(/,/g, ''), 10);
+    if (Number.isFinite(n)) return n;
+  }
+  // Fall back to a plain run of digits.
+  const plain = text.match(/\d+/);
+  if (!plain) return null;
+  const n = parseInt(plain[0], 10);
   return Number.isFinite(n) ? n : null;
 }
 
@@ -187,8 +198,9 @@ function buildStructuredUpdates(
     }
   }
 
-  // refrigeration — Select with 'yes' / 'no' / 'unsure'. 'unsure' deliberately
-  // does NOT write the boolean column (leaves it null = unknown).
+  // refrigeration — Select with 'yes' / 'no' / 'unsure'. Picking Unsure
+  // explicitly clears the column back to null (unknown), so operators can
+  // walk back a previously-recorded value when something changes.
   const refrigValue = itemAnswers.refrigeration?.trim().toLowerCase();
   if (refrigValue === 'yes' || refrigValue === 'no') {
     const bool = refrigValue === 'yes';
@@ -197,6 +209,13 @@ function buildStructuredUpdates(
       itemId: 'refrigeration',
       column: 'has refrigeration',
       display: bool ? 'Yes' : 'No',
+    });
+  } else if (refrigValue === 'unsure') {
+    updates.hasRefrigeration = null;
+    mapped.push({
+      itemId: 'refrigeration',
+      column: 'has refrigeration',
+      display: 'Unsure (cleared)',
     });
   }
 

--- a/client/src/components/event-requests/IntakeCallDialog.tsx
+++ b/client/src/components/event-requests/IntakeCallDialog.tsx
@@ -30,6 +30,13 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
 import {
@@ -75,6 +82,126 @@ const OPERATING_AREAS = [
   'Marietta',
   'Roswell',
 ];
+
+// Extract the first integer from an operator's free-text answer.
+// Handles "750", "around 200", "750ish", "approximately 1000".
+// For ranges like "200-300" returns the first number (200) — operator can
+// adjust on the event after intake if needed.
+function parseNumberFromText(text: string): number | null {
+  const match = text.match(/\d+/);
+  if (!match) return null;
+  const n = parseInt(match[0], 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+// Convert a native date-input value (YYYY-MM-DD) into a friendlier display
+// string for the planningNotes summary block.
+function formatIsoDateForNotes(dateStr: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return dateStr;
+  const [y, m, d] = dateStr.split('-');
+  return `${m}/${d}/${y}`;
+}
+
+// Friendlier display for itemAnswers values when summarizing into planningNotes.
+function formatItemAnswerForNotes(itemId: string, value: string): string {
+  if (itemId === 'event_date') return formatIsoDateForNotes(value);
+  if (itemId === 'refrigeration') {
+    return value.charAt(0).toUpperCase() + value.slice(1);
+  }
+  return value;
+}
+
+interface StructuredIntakeResult {
+  updates: Record<string, unknown>;
+  // Per-field mapping result for surfacing in the success toast.
+  mapped: Array<{ itemId: string; column: string; display: string }>;
+  // Items the operator filled in but we couldn't parse — fall back to
+  // planningNotes; warn the user so they know structured data was missed.
+  unparseable: Array<{ itemId: string; rawValue: string }>;
+}
+
+// Parse the structured intake fields out of itemAnswers and build a partial
+// update payload of typed column values. Items that don't parse cleanly are
+// surfaced separately so the user can be warned in the toast rather than
+// having the data silently dropped.
+function buildStructuredUpdates(
+  itemAnswers: Record<string, string>
+): StructuredIntakeResult {
+  const updates: Record<string, unknown> = {};
+  const mapped: StructuredIntakeResult['mapped'] = [];
+  const unparseable: StructuredIntakeResult['unparseable'] = [];
+
+  // event_date — native date input gives YYYY-MM-DD.
+  // Always writes to desiredEventDate; the audit log preserves any prior
+  // value so the original requested date is recoverable from history.
+  const dateValue = itemAnswers.event_date?.trim();
+  if (dateValue) {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(dateValue)) {
+      // Parse as local midnight to avoid a one-day UTC drift when the
+      // server converts the timestamp.
+      const [y, m, d] = dateValue.split('-').map(Number);
+      const dt = new Date(y, m - 1, d);
+      updates.desiredEventDate = dt.toISOString();
+      mapped.push({
+        itemId: 'event_date',
+        column: 'desired event date',
+        display: formatIsoDateForNotes(dateValue),
+      });
+    } else {
+      unparseable.push({ itemId: 'event_date', rawValue: dateValue });
+    }
+  }
+
+  // sandwich_count — free text → integer.
+  const sandwichValue = itemAnswers.sandwich_count?.trim();
+  if (sandwichValue) {
+    const n = parseNumberFromText(sandwichValue);
+    if (n !== null) {
+      updates.estimatedSandwichCount = n;
+      mapped.push({
+        itemId: 'sandwich_count',
+        column: 'estimated sandwich count',
+        display: String(n),
+      });
+    } else {
+      unparseable.push({ itemId: 'sandwich_count', rawValue: sandwichValue });
+    }
+  }
+
+  // participant_count — free text → integer.
+  const participantValue = itemAnswers.participant_count?.trim();
+  if (participantValue) {
+    const n = parseNumberFromText(participantValue);
+    if (n !== null) {
+      updates.estimatedAttendance = n;
+      mapped.push({
+        itemId: 'participant_count',
+        column: 'estimated attendance',
+        display: String(n),
+      });
+    } else {
+      unparseable.push({
+        itemId: 'participant_count',
+        rawValue: participantValue,
+      });
+    }
+  }
+
+  // refrigeration — Select with 'yes' / 'no' / 'unsure'. 'unsure' deliberately
+  // does NOT write the boolean column (leaves it null = unknown).
+  const refrigValue = itemAnswers.refrigeration?.trim().toLowerCase();
+  if (refrigValue === 'yes' || refrigValue === 'no') {
+    const bool = refrigValue === 'yes';
+    updates.hasRefrigeration = bool;
+    mapped.push({
+      itemId: 'refrigeration',
+      column: 'has refrigeration',
+      display: bool ? 'Yes' : 'No',
+    });
+  }
+
+  return { updates, mapped, unparseable };
+}
 
 const IntakeCallDialog: React.FC<IntakeCallDialogProps> = ({
   isOpen,
@@ -151,6 +278,39 @@ const IntakeCallDialog: React.FC<IntakeCallDialogProps> = ({
       initialAnswers.contact_email = req.email;
       initialChecked.add('contact_email');
     }
+
+    // Pre-fill the structured checklist items from existing event data so
+    // the operator sees what we already know and only re-types if it changed.
+    if (req.desiredEventDate) {
+      const d = new Date(req.desiredEventDate);
+      if (!Number.isNaN(d.getTime())) {
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        initialAnswers.event_date = `${y}-${m}-${day}`;
+        initialChecked.add('event_date');
+      }
+    }
+    if (req.estimatedSandwichCount != null) {
+      initialAnswers.sandwich_count = String(req.estimatedSandwichCount);
+      initialChecked.add('sandwich_count');
+    }
+    if (req.estimatedAttendance != null) {
+      initialAnswers.participant_count = String(req.estimatedAttendance);
+      initialChecked.add('participant_count');
+    }
+    if (req.hasRefrigeration === true) {
+      initialAnswers.refrigeration = 'yes';
+      initialChecked.add('refrigeration');
+    } else if (req.hasRefrigeration === false) {
+      initialAnswers.refrigeration = 'no';
+      initialChecked.add('refrigeration');
+    }
+    if (req.eventAddress) {
+      initialAnswers.event_address = req.eventAddress;
+      initialChecked.add('event_address');
+    }
+
     setItemAnswers(initialAnswers);
     setCheckedItems(initialChecked);
     setCallNotes('');
@@ -269,7 +429,8 @@ const IntakeCallDialog: React.FC<IntakeCallDialogProps> = ({
         `Intake call completed: ${nowLabel}`,
         `Contact: ${contactName || 'N/A'} | ${contactPhone || 'N/A'} | ${contactEmail || 'N/A'}`,
         ...answeredItems.map(
-          (item) => `- ${item.label}: ${itemAnswers[item.id].trim()}`
+          (item) =>
+            `- ${item.label}: ${formatItemAnswerForNotes(item.id, itemAnswers[item.id].trim())}`
         ),
       ];
 
@@ -283,7 +444,11 @@ const IntakeCallDialog: React.FC<IntakeCallDialogProps> = ({
         ? `${existingNotes}\n\n${summaryBlock}`
         : summaryBlock;
 
+      // Build structured updates first so they don't get overwritten by
+      // the explicit contact/address mappings below if there's any overlap.
+      const structured = buildStructuredUpdates(itemAnswers);
       const updates: Record<string, unknown> = {
+        ...structured.updates,
         planningNotes: updatedPlanningNotes,
       };
 
@@ -308,9 +473,30 @@ const IntakeCallDialog: React.FC<IntakeCallDialogProps> = ({
 
       await apiRequest('PATCH', `/api/event-requests/${eventRequest?.id}`, updates);
 
+      // Build a toast that tells the operator exactly which structured fields
+      // got mapped to columns and which inputs couldn't be parsed (those still
+      // live in planningNotes, but the operator should know they're not
+      // searchable/reportable as structured data).
+      const toastParts: string[] = ['Notes and contact updates saved.'];
+      if (structured.mapped.length > 0) {
+        toastParts.push(
+          'Saved to event: ' +
+            structured.mapped.map((m) => `${m.column} (${m.display})`).join(', ')
+        );
+      }
+      const hasUnparseable = structured.unparseable.length > 0;
+      if (hasUnparseable) {
+        toastParts.push(
+          "Couldn't parse: " +
+            structured.unparseable.map((u) => u.itemId).join(', ') +
+            ' — kept in notes only.'
+        );
+      }
       toast({
-        title: 'Intake call saved',
-        description: 'Notes and contact updates have been saved.',
+        title: hasUnparseable ? 'Intake call saved (with warnings)' : 'Intake call saved',
+        description: toastParts.join(' '),
+        variant: hasUnparseable ? 'destructive' : 'default',
+        duration: hasUnparseable ? 12000 : 5000,
       });
 
       // Save succeeded — clear the autosaved draft for this event.
@@ -805,6 +991,33 @@ const IntakeCallDialog: React.FC<IntakeCallDialogProps> = ({
                               className="text-sm h-8"
                               onClick={(e) => e.stopPropagation()}
                             />
+                          ) : item.id === 'event_date' ? (
+                            <Input
+                              type="date"
+                              value={itemAnswers[item.id] || ''}
+                              onChange={(e) =>
+                                handleAnswerChange(item.id, e.target.value)
+                              }
+                              className="text-sm h-8"
+                              onClick={(e) => e.stopPropagation()}
+                            />
+                          ) : item.id === 'refrigeration' ? (
+                            <Select
+                              value={itemAnswers[item.id] || ''}
+                              onValueChange={(v) => handleAnswerChange(item.id, v)}
+                            >
+                              <SelectTrigger
+                                className="text-sm h-8"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <SelectValue placeholder="Yes / No / Unsure" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="yes">Yes</SelectItem>
+                                <SelectItem value="no">No</SelectItem>
+                                <SelectItem value="unsure">Unsure</SelectItem>
+                              </SelectContent>
+                            </Select>
                           ) : (
                             <Input
                               type="text"

--- a/client/src/components/event-requests/IntakeCallDialog.tsx
+++ b/client/src/components/event-requests/IntakeCallDialog.tsx
@@ -150,16 +150,16 @@ function buildStructuredUpdates(
   // event_date — native date input gives YYYY-MM-DD.
   // Always writes to desiredEventDate; the audit log preserves any prior
   // value so the original requested date is recoverable from history.
-  // Uses shared parseDateOnly so the timestamp matches every other date
-  // handler in the app (local noon, not local midnight). This is critical
-  // both for timezone safety AND so that re-saving an unchanged date is a
-  // true no-op rather than a noon→midnight shift that would generate a
-  // spurious audit entry.
+  //
+  // We send the bare YYYY-MM-DD string (not a full ISO timestamp) so the
+  // server's parseDateOnly does the timezone-safe conversion in one place
+  // — that matches how the rest of the codebase serializes date-only
+  // fields and avoids a client→ISO→server round-trip that could reintroduce
+  // drift. parseDateOnly is still called client-side just to validate.
   const dateValue = itemAnswers.event_date?.trim();
   if (dateValue) {
-    const parsed = parseDateOnly(dateValue);
-    if (parsed) {
-      updates.desiredEventDate = parsed.toISOString();
+    if (parseDateOnly(dateValue)) {
+      updates.desiredEventDate = dateValue;
       mapped.push({
         itemId: 'event_date',
         column: 'desired event date',

--- a/client/src/components/event-requests/IntakeCallDialog.tsx
+++ b/client/src/components/event-requests/IntakeCallDialog.tsx
@@ -40,6 +40,11 @@ import {
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
 import {
+  parseDateOnly,
+  toDateOnlyString,
+  formatDateShort,
+} from '@shared/date-utils';
+import {
   useDraftPersistence,
   loadDraft,
   clearDraft,
@@ -106,11 +111,11 @@ function parseNumberFromText(text: string): number | null {
 }
 
 // Convert a native date-input value (YYYY-MM-DD) into a friendlier display
-// string for the planningNotes summary block.
+// string for the planningNotes summary block. Uses the shared date utility
+// so we render consistently with the rest of the app (Eastern Time).
 function formatIsoDateForNotes(dateStr: string): string {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return dateStr;
-  const [y, m, d] = dateStr.split('-');
-  return `${m}/${d}/${y}`;
+  return formatDateShort(dateStr);
 }
 
 // Friendlier display for itemAnswers values when summarizing into planningNotes.
@@ -145,14 +150,16 @@ function buildStructuredUpdates(
   // event_date — native date input gives YYYY-MM-DD.
   // Always writes to desiredEventDate; the audit log preserves any prior
   // value so the original requested date is recoverable from history.
+  // Uses shared parseDateOnly so the timestamp matches every other date
+  // handler in the app (local noon, not local midnight). This is critical
+  // both for timezone safety AND so that re-saving an unchanged date is a
+  // true no-op rather than a noon→midnight shift that would generate a
+  // spurious audit entry.
   const dateValue = itemAnswers.event_date?.trim();
   if (dateValue) {
-    if (/^\d{4}-\d{2}-\d{2}$/.test(dateValue)) {
-      // Parse as local midnight to avoid a one-day UTC drift when the
-      // server converts the timestamp.
-      const [y, m, d] = dateValue.split('-').map(Number);
-      const dt = new Date(y, m - 1, d);
-      updates.desiredEventDate = dt.toISOString();
+    const parsed = parseDateOnly(dateValue);
+    if (parsed) {
+      updates.desiredEventDate = parsed.toISOString();
       mapped.push({
         itemId: 'event_date',
         column: 'desired event date',
@@ -300,13 +307,13 @@ const IntakeCallDialog: React.FC<IntakeCallDialogProps> = ({
 
     // Pre-fill the structured checklist items from existing event data so
     // the operator sees what we already know and only re-types if it changed.
+    // Uses shared toDateOnlyString so the pre-fill matches the convention
+    // used everywhere else in the app (and any future fixes to timezone
+    // handling apply automatically rather than needing patches here too).
     if (req.desiredEventDate) {
-      const d = new Date(req.desiredEventDate);
-      if (!Number.isNaN(d.getTime())) {
-        const y = d.getFullYear();
-        const m = String(d.getMonth() + 1).padStart(2, '0');
-        const day = String(d.getDate()).padStart(2, '0');
-        initialAnswers.event_date = `${y}-${m}-${day}`;
+      const dateStr = toDateOnlyString(req.desiredEventDate);
+      if (dateStr) {
+        initialAnswers.event_date = dateStr;
         initialChecked.add('event_date');
       }
     }
@@ -505,9 +512,17 @@ const IntakeCallDialog: React.FC<IntakeCallDialogProps> = ({
       }
       const hasUnparseable = structured.unparseable.length > 0;
       if (hasUnparseable) {
+        // Translate internal item ids back to the checklist labels the
+        // operator actually sees on screen — "sandwich_count" reads as
+        // jargon, "Number of sandwiches" is what they typed under.
+        const labelById = new Map(
+          checklistItems.map((item) => [item.id, item.label])
+        );
         toastParts.push(
           "Couldn't parse: " +
-            structured.unparseable.map((u) => u.itemId).join(', ') +
+            structured.unparseable
+              .map((u) => labelById.get(u.itemId) ?? u.itemId)
+              .join(', ') +
             ' — kept in notes only.'
         );
       }


### PR DESCRIPTION
The intake dialog was dumping nearly all collected data into a single planningNotes text blob — operators would later have to re-enter sandwich count, event date, attendance, etc. into structured fields via EventEditDialog, which is where the silent-save bugs were reported. Now the intake call also writes typed values directly:

  event_date        → desiredEventDate (native date picker)
  sandwich_count    → estimatedSandwichCount (free text, parsed to int)
  participant_count → estimatedAttendance (free text, parsed to int)
  refrigeration     → hasRefrigeration (Yes/No/Unsure select)
  event_address     → eventAddress (already mapped)

Existing values are pre-filled when the dialog opens so the operator sees what we already know and only re-types if it changed. The planningNotes summary still captures everything as a transcript-style backup. The success toast names each field that got mapped and warns about any inputs that couldn't be parsed (e.g. operator typed "sometime in spring" for a number field) so the data loss is visible rather than silent.

https://claude.ai/code/session_01EeRmttFp2CPWqZ9Dspt51N

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how operators persist core planning fields (date, counts, refrigeration) on event requests via PATCH; parsing edge cases are surfaced in the UI but wrong numbers could still be saved if text parses unexpectedly.
> 
> **Overview**
> Intake call completion now **writes checklist answers into structured event fields** on the same `PATCH` that already saves contact info and `planningNotes`, instead of leaving counts, date, and refrigeration only in the notes blob.
> 
> On save, `buildStructuredUpdates` maps **event date** → `desiredEventDate` (validated `YYYY-MM-DD`), **sandwich / participant** free text → `estimatedSandwichCount` / `estimatedAttendance` via `parseNumberFromText`, and **refrigeration** (Yes/No/Unsure) → `hasRefrigeration` (Unsure clears to `null`). Unparseable values stay in notes; the toast lists what was mapped and flags fields that stayed notes-only.
> 
> When the dialog opens, known values are **pre-filled** from the request (including date via `toDateOnlyString`). The checklist uses a **date** input for event date and a **select** for refrigeration; the notes summary uses friendlier formatting for those fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f95b453a50c5d16707034a74a00cdfac62828f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->