### PR TITLE
Fix "Mark Scheduled" save silently failing on every event

### DIFF
--- a/client/src/components/event-requests/EventSchedulingForm.tsx
+++ b/client/src/components/event-requests/EventSchedulingForm.tsx
@@ -58,6 +58,7 @@ import {
   buildEventDataForServer,
   detectChangedFields,
   findMismatchedSavedFields,
+  getDroppedServerFields,
   determineSandwichMode,
   determineActualSandwichMode,
   calculateRelevantSandwichCount,
@@ -767,25 +768,25 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
       setIsSubmitting(false);
       const orgName = eventRequest?.organizationName || formData.organizationName || 'Event';
 
-      const droppedFields: Array<{ field: string; reason: string }> | undefined = updatedEvent?._droppedFields;
+      // Only the server-reported dropped fields are authoritative enough to block
+      // save completion. The heuristic round-trip comparison below is logged for
+      // diagnostics but must NOT keep the dialog open — treating its false
+      // positives as failures made every save look like it silently didn't save.
+      const droppedFields = getDroppedServerFields(updatedEvent);
       const mismatchedFields = findMismatchedSavedFields(variables.data || {}, updatedEvent);
-      if (
-        (Array.isArray(droppedFields) && droppedFields.length > 0) ||
-        mismatchedFields.length > 0
-      ) {
+      if (mismatchedFields.length > 0) {
+        logger.warn(
+          '[EventSchedulingForm] Post-save field comparison flagged (non-blocking):',
+          mismatchedFields,
+        );
+      }
+      if (droppedFields.length > 0) {
         saveToLocalStorage();
         await invalidateEventRequestQueries(queryClient);
 
-        const droppedSummary = Array.isArray(droppedFields) && droppedFields.length > 0
-          ? `Not saved: ${droppedFields.map((d) => `${d.field} (${d.reason})`).join(', ')}`
-          : '';
-        const mismatchSummary = mismatchedFields.length > 0
-          ? `Needs review: ${mismatchedFields.join(', ')} did not match the saved response.`
-          : '';
-
         toast({
           title: 'Partial Save - Please Review',
-          description: [droppedSummary, mismatchSummary].filter(Boolean).join(' '),
+          description: `Not saved: ${droppedFields.map((d) => `${d.field} (${d.reason})`).join(', ')}`,
           variant: 'destructive',
           duration: Number.POSITIVE_INFINITY,
         });

--- a/client/src/components/event-requests/__tests__/mark-scheduled-save.test.ts
+++ b/client/src/components/event-requests/__tests__/mark-scheduled-save.test.ts
@@ -1,0 +1,76 @@
+jest.mock('@/lib/logger', () => ({ logger: { log() {}, warn() {}, error() {}, info() {} } }));
+jest.mock('@/lib/queryClient', () => ({ apiRequest: jest.fn() }));
+
+import { findMismatchedSavedFields, getDroppedServerFields } from '../form-utils';
+
+/**
+ * Regression coverage for the "Mark Scheduled won't save" bug.
+ *
+ * A successful (HTTP 200) PATCH used to be treated as a *partial* save — keeping
+ * the dialog open and preserving the draft — whenever the heuristic
+ * `findMismatchedSavedFields` flagged any field. That heuristic produces false
+ * positives for routine server behaviour, so every save looked like it silently
+ * failed. The fix: only the server-authoritative `_droppedFields` marker may
+ * block save completion.
+ */
+describe('Mark Scheduled save completion gating', () => {
+  it('does NOT block a successful save just because the heuristic comparison flags fields', () => {
+    // A realistic PATCH payload sent when marking an event scheduled.
+    const sentPayload: Record<string, any> = {
+      status: 'scheduled',
+      scheduledEventDate: '2026-06-15',
+      desiredEventDate: '2026-06-15',
+      vanDriverNeeded: false,
+      isDhlVan: false,
+      selfTransport: false,
+      driversNeeded: 0,
+      sandwichTypes: JSON.stringify([]),
+      assignedRecipientIds: [],
+    };
+
+    // A realistic server response: the event WAS saved, but the server transforms
+    // / omits some fields (null vs false, auto-bumped counts, join-table arrays,
+    // parsed JSON columns). No `_droppedFields` marker => nothing was actually dropped.
+    const savedEvent: Record<string, any> = {
+      id: 123,
+      status: 'scheduled',
+      scheduledEventDate: '2026-06-15T12:00:00.000Z',
+      desiredEventDate: '2026-06-15T12:00:00.000Z',
+      vanDriverNeeded: null, // server stored null, client sent false
+      isDhlVan: false,
+      selfTransport: false,
+      driversNeeded: 2, // server auto-bumped to match assigned drivers
+      sandwichTypes: [], // jsonb column returned as a parsed array, not a string
+      isConfirmed: true,
+      // assignedRecipientIds intentionally absent (stored in a join table)
+    };
+
+    // The heuristic comparison flags several fields (this is expected & why it
+    // must not be used to block saves)...
+    const mismatched = findMismatchedSavedFields(sentPayload, savedEvent);
+    expect(mismatched.length).toBeGreaterThan(0);
+
+    // ...but since the server reported no dropped fields, the save must complete.
+    expect(getDroppedServerFields(savedEvent)).toEqual([]);
+  });
+
+  it('DOES surface a partial save when the server reports dropped fields', () => {
+    const savedEvent: Record<string, any> = {
+      id: 123,
+      status: 'scheduled',
+      _droppedFields: [
+        { field: 'addedToOfficialSheetAt', reason: 'Database column not available on this branch (migration pending)' },
+      ],
+    };
+
+    const dropped = getDroppedServerFields(savedEvent);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].field).toBe('addedToOfficialSheetAt');
+  });
+
+  it('treats a response with no marker as a clean save', () => {
+    expect(getDroppedServerFields({ id: 1, status: 'scheduled' })).toEqual([]);
+    expect(getDroppedServerFields(null)).toEqual([]);
+    expect(getDroppedServerFields(undefined)).toEqual([]);
+  });
+});

--- a/client/src/components/event-requests/form-utils.ts
+++ b/client/src/components/event-requests/form-utils.ts
@@ -9,7 +9,7 @@
 
 import { FIELD_MAPPINGS } from './fieldConfig';
 import type { EventFormData } from './form-sections/types';
-export { findMismatchedSavedFields } from '@/lib/event-save-verification';
+export { findMismatchedSavedFields, getDroppedServerFields } from '@/lib/event-save-verification';
 
 /**
  * Serialize a date string for the backend.

--- a/client/src/lib/event-save-verification.ts
+++ b/client/src/lib/event-save-verification.ts
@@ -43,6 +43,27 @@ function normalizeDateForCompare(value: any): string | null {
   return match ? match[1] : value;
 }
 
+/**
+ * Return the fields the server *explicitly* reported as dropped during a save.
+ *
+ * This is the only authoritative signal that a successful (HTTP 200) PATCH did
+ * not fully persist. `findMismatchedSavedFields` below is a heuristic best-effort
+ * comparison and is NOT reliable enough to block a save: the server legitimately
+ * transforms many fields (auto-bumps `driversNeeded`/`speakersNeeded`, sets
+ * `isConfirmed`, normalizes dates, returns `null` where the client sent `false`,
+ * stores recipients/assignments in join tables, parses JSON columns, etc.).
+ * Treating those heuristic mismatches as failures made every "Mark Scheduled"
+ * save appear to silently not save — the dialog stayed open and the draft was
+ * preserved even though the event had actually been saved.
+ */
+export function getDroppedServerFields(
+  savedEvent: Record<string, any> | null | undefined
+): DroppedEventField[] {
+  return Array.isArray(savedEvent?._droppedFields)
+    ? (savedEvent!._droppedFields as DroppedEventField[])
+    : [];
+}
+
 export function findMismatchedSavedFields(
   expectedUpdates: Record<string, any>,
   savedEvent: Record<string, any> | null | undefined


### PR DESCRIPTION
## Problem

Clicking **Mark Scheduled** on an event card and saving appeared to do nothing — the event never got scheduled. This happened on **every** event.

## Root cause

A recently added post-save verification (commit `20f6782`, "Save Verification") compares each field the client sent against the field values the server echoes back. In `onSuccess`, if **any** field didn't match exactly, it showed a persistent `Partial Save - Please Review` toast and **returned early — never closing the dialog and never clearing the draft**, so a successful (HTTP 200) save looked like it silently failed.

That comparison (`findMismatchedSavedFields`) is unreliable as a blocking gate because the server legitimately transforms or omits fields on the way back:

- returns `null` where the client sent `false` (`vanDriverNeeded` / `isDhlVan` / `selfTransport`)
- auto-bumps `driversNeeded` / `speakersNeeded` to match assignments
- returns recipients/assignments from join tables (field absent in the row)
- returns `jsonb` columns parsed (array) vs the JSON string sent
- normalizes dates

So it produced false positives on essentially every save. A reproduction confirmed it flagged 9 fields on an otherwise-clean scheduling payload.

## Fix

Only the server-authoritative `_droppedFields` marker may block save completion — the server explicitly lists fields it actually dropped. The heuristic comparison is kept purely as a non-blocking diagnostic log, so a successful save now always clears the draft, shows success, and closes the dialog.

- `event-save-verification.ts` — add `getDroppedServerFields` (authoritative check) + docs on why the heuristic can't gate saves
- `EventSchedulingForm.tsx` — block on `getDroppedServerFields` only; log mismatches non-blocking
- `form-utils.ts` — re-export the new helper
- `__tests__/mark-scheduled-save.test.ts` — regression tests

## Tests

`npx jest --config jest.config.client.js .../mark-scheduled-save.test.ts` — 3 passing:
- a successful save with cosmetic mismatches is **not** blocked
- a server-reported dropped field **still** surfaces a partial-save warning
- a response with no marker is treated as a clean save

## Note

The user reported seeing *no* toast at all (rather than the warning). This fix removes the blocking warning that was the most likely culprit and matches this being a recent regression. If "Mark Scheduled" still does nothing with no message after deploy, the next place to look is the form-submit wiring.

https://claude.ai/code/session_01RdNWG25SG6nkf1rsFM9LLT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdNWG25SG6nkf1rsFM9LLT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only change to post-save UX in the scheduling form; reduces false “partial save” blocking while preserving warnings when the server explicitly reports dropped fields.
> 
> **Overview**
> Fixes **Mark Scheduled** (and other scheduling saves) appearing to fail even when the server returned HTTP 200. Post-save handling no longer treats `findMismatchedSavedFields` mismatches as a blocking partial save; only the server’s `_droppedFields` list can keep the dialog open and show **Partial Save - Please Review**.
> 
> `getDroppedServerFields` is added in `event-save-verification.ts` (with documentation on why the round-trip heuristic is diagnostic-only). `EventSchedulingForm` uses it in `onSuccess`, logs mismatches via `logger.warn` without blocking, and still surfaces a destructive toast when fields were actually dropped. Regression tests in `mark-scheduled-save.test.ts` lock in that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5c4fc871c0e1b870895cd3688bd12e6d358aa6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->