### PR TITLE
Claude/mark scheduled save bug tph ye

### DIFF
--- a/client/src/components/event-requests/EventSchedulingForm.tsx
+++ b/client/src/components/event-requests/EventSchedulingForm.tsx
@@ -920,7 +920,10 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
 
   const performSubmit = async (skipSpeakerWarning = false, fieldOverrides?: Record<string, any>) => {
     setIsSubmitting(true);
-    clearAutoSave();
+    // NOTE: the recovery draft is intentionally cleared only after a successful
+    // save (in the mutation onSuccess handlers). Clearing it here would wipe the
+    // user's unsaved edits if the save then failed (network drop, timeout, 4xx/5xx).
+    // The auto-save effect is suppressed while isSubmitting is true.
 
     // Block submission if form not initialized
     if (eventRequest && !formInitialized) {
@@ -1021,8 +1024,8 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
 
   // ── Form Submit Handler ────────────────────────────────────────────
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = async (e?: React.FormEvent | React.MouseEvent) => {
+    e?.preventDefault?.();
 
     // Non-blocking van conflict check
     if (eventLikelyNeedsVan() && !vanConflictChecked) {
@@ -1435,6 +1438,12 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
             <Button type="submit" form="event-scheduling-form" className="text-white"
               style={{ backgroundColor: '#236383' }}
               disabled={isSubmitting || updateEventRequestMutation.isPending || createEventRequestMutation.isPending}
+              // Belt-and-suspenders: this button lives outside the <form>, so it relies on the
+              // `form` attribute to submit. Some browser/portal combinations don't honor that
+              // association, which made the button appear to do nothing. The onClick triggers the
+              // save directly. The button stays disabled while a save is in flight, and the submit
+              // event itself is suppressed when this fires, so there is no double submission.
+              onClick={(e) => { e.preventDefault(); handleSubmit(e); }}
               data-testid="button-submit">
               {(updateEventRequestMutation.isPending || createEventRequestMutation.isPending)
                 ? (mode === 'edit' ? 'Saving...' : 'Scheduling...')

--- a/client/src/components/event-requests/EventSchedulingForm.tsx
+++ b/client/src/components/event-requests/EventSchedulingForm.tsx
@@ -1435,14 +1435,16 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
           </div>
           <div className="flex space-x-3">
             <Button type="button" variant="outline" onClick={onClose}>Cancel</Button>
+            {/*
+              Belt-and-suspenders: this button lives outside the <form>, so it relies on the
+              `form` attribute to submit. Some browser/portal combinations don't honor that
+              association, which made the button appear to do nothing. The onClick triggers the
+              save directly. preventDefault suppresses the native form submit so there is no
+              double submission, and the button stays disabled while a save is in flight.
+            */}
             <Button type="submit" form="event-scheduling-form" className="text-white"
               style={{ backgroundColor: '#236383' }}
               disabled={isSubmitting || updateEventRequestMutation.isPending || createEventRequestMutation.isPending}
-              // Belt-and-suspenders: this button lives outside the <form>, so it relies on the
-              // `form` attribute to submit. Some browser/portal combinations don't honor that
-              // association, which made the button appear to do nothing. The onClick triggers the
-              // save directly. The button stays disabled while a save is in flight, and the submit
-              // event itself is suppressed when this fires, so there is no double submission.
               onClick={(e) => { e.preventDefault(); handleSubmit(e); }}
               data-testid="button-submit">
               {(updateEventRequestMutation.isPending || createEventRequestMutation.isPending)

--- a/client/src/components/event-requests/__tests__/mark-scheduled-save.test.ts
+++ b/client/src/components/event-requests/__tests__/mark-scheduled-save.test.ts
@@ -1,7 +1,68 @@
 jest.mock('@/lib/logger', () => ({ logger: { log() {}, warn() {}, error() {}, info() {} } }));
 jest.mock('@/lib/queryClient', () => ({ apiRequest: jest.fn() }));
 
-import { findMismatchedSavedFields, getDroppedServerFields } from '../form-utils';
+import {
+  findMismatchedSavedFields,
+  getDroppedServerFields,
+  buildEventDataForServer,
+  detectChangedFields,
+} from '../form-utils';
+
+const baseFormData: any = {
+  eventDate: '2026-06-15',
+  backupDates: [],
+  sandwichTypes: [],
+  totalSandwichCount: 100,
+  estimatedSandwichCountMin: 0,
+  estimatedSandwichCountMax: 0,
+  actualSandwichTypes: [],
+  assignedRecipientIds: [],
+  speakersNeeded: 0,
+  driversNeeded: 0,
+  volunteersNeeded: 0,
+};
+
+function buildSchedulePayload(formStatus: string) {
+  const formData = { ...baseFormData, status: formStatus };
+  const original = { ...baseFormData, status: 'in_process' };
+  const eventData = buildEventDataForServer(formData, {
+    mode: 'schedule',
+    hasEventRequest: true,
+    eventRequestStatus: 'in_process',
+    sandwichMode: 'total',
+    actualSandwichMode: 'total',
+  });
+  return detectChangedFields(eventData, original, 'schedule');
+}
+
+describe('Mark Scheduled status handling', () => {
+  it('defaults the saved status to "scheduled" and includes the scheduled date', () => {
+    const payload = buildSchedulePayload('scheduled');
+    expect(payload.status).toBe('scheduled');
+    expect(payload.scheduledEventDate).toBe('2026-06-15');
+  });
+
+  it('respects an explicit non-scheduled choice (e.g. Standby) instead of forcing scheduled', () => {
+    const payload = buildSchedulePayload('standby');
+    expect(payload.status).toBe('standby');
+    // No scheduled date should be attached when the user is not actually scheduling.
+    expect(payload.scheduledEventDate).toBeUndefined();
+  });
+
+  it('falls back to "scheduled" when the form has no status set', () => {
+    const formData = { ...baseFormData };
+    delete formData.status;
+    const eventData = buildEventDataForServer(formData, {
+      mode: 'schedule',
+      hasEventRequest: true,
+      eventRequestStatus: 'in_process',
+      sandwichMode: 'total',
+      actualSandwichMode: 'total',
+    });
+    const payload = detectChangedFields(eventData, { ...baseFormData, status: 'in_process' }, 'schedule');
+    expect(payload.status).toBe('scheduled');
+  });
+});
 
 /**
  * Regression coverage for the "Mark Scheduled won't save" bug.

--- a/client/src/components/event-requests/form-utils.ts
+++ b/client/src/components/event-requests/form-utils.ts
@@ -46,7 +46,7 @@ export function buildEventDataForServer(
 
   const eventData: Record<string, any> = {
     // Status logic: different handling per mode
-    ...(hasEventRequest && mode === 'schedule' ? { status: 'scheduled' } : {}),
+    ...(hasEventRequest && mode === 'schedule' ? { status: formData.status || 'scheduled' } : {}),
     ...(!hasEventRequest ? { status: formData.status || 'new' } : {}),
     ...(hasEventRequest && mode === 'edit' ? { status: formData.status || eventRequestStatus || 'new' } : {}),
 
@@ -284,16 +284,21 @@ export function detectChangedFields(
     }
   });
 
-  // Schedule mode safety: always ensure status and date are present
+  // Schedule mode safety: always ensure status and date are present.
+  // Status defaults to 'scheduled' (the whole point of this dialog) but respects
+  // an explicit choice the user made in the dropdown (e.g. Standby) rather than
+  // silently forcing 'scheduled'.
   if (mode === 'schedule') {
-    filteredEventData.status = 'scheduled';
-    // Always include scheduledEventDate in schedule mode - use the date from eventData
-    const schedDate = eventData.scheduledEventDate || eventData.desiredEventDate;
-    if (schedDate) {
-      filteredEventData.scheduledEventDate = schedDate;
+    const resolvedStatus = eventData.status || 'scheduled';
+    filteredEventData.status = resolvedStatus;
+    // Only attach the scheduled date when the event is actually being scheduled.
+    if (resolvedStatus === 'scheduled') {
+      const schedDate = eventData.scheduledEventDate || eventData.desiredEventDate;
+      if (schedDate) {
+        filteredEventData.scheduledEventDate = schedDate;
+      }
     }
-    // Also always include desiredEventDate if it has a value, so the date is never lost
-    // when scheduling an event
+    // Always include desiredEventDate if it has a value, so the date is never lost.
     if (eventData.desiredEventDate) {
       filteredEventData.desiredEventDate = eventData.desiredEventDate;
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes event lifecycle status/date fields sent on PATCH and autosave timing; mistakes could mis-schedule events or lose drafts, but scope is limited to the scheduling form utilities and tests.
> 
> **Overview**
> Fixes **Mark Scheduled** saves that looked broken or lost work: schedule-mode payloads now use the form’s **status** (defaulting to `scheduled`, but honoring choices like **Standby**) and only send **`scheduledEventDate`** when status is actually `scheduled`.
> 
> **`EventSchedulingForm`** no longer clears the local recovery draft at the start of submit—drafts are cleared only after a successful save, with auto-save paused while submitting. The footer **Save** button (outside the `<form>`) now calls **`handleSubmit`** directly so saves work when the `form` attribute isn’t honored.
> 
> Adds regression tests for schedule payload status/date behavior and existing save-completion gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4239fb2bed0f6d13f9071a579765759003498339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->