### PR TITLE
Fix scheduledEventDate leaking when a non-scheduled status is saved from the scheduling dialog

### DIFF
--- a/client/src/components/event-requests/__tests__/mark-scheduled-save.test.ts
+++ b/client/src/components/event-requests/__tests__/mark-scheduled-save.test.ts
@@ -49,6 +49,44 @@ describe('Mark Scheduled status handling', () => {
     expect(payload.scheduledEventDate).toBeUndefined();
   });
 
+  it('does NOT leak scheduledEventDate when status is non-scheduled AND the date changed', () => {
+    // Regression: opening "Mark Scheduled", picking Standby, and ALSO changing the date.
+    // The form is in schedule mode so scheduledEventDate is populated, and because the
+    // date differs from the original, change-detection would include it. It must be
+    // stripped so a confirmed scheduled date isn't sent alongside a standby status.
+    const formData = { ...baseFormData, status: 'standby', eventDate: '2026-07-20' };
+    const original = { ...baseFormData, status: 'in_process', eventDate: '2026-06-15' };
+    const eventData = buildEventDataForServer(formData, {
+      mode: 'schedule',
+      hasEventRequest: true,
+      eventRequestStatus: 'in_process',
+      sandwichMode: 'total',
+      actualSandwichMode: 'total',
+    });
+    const payload = detectChangedFields(eventData, original, 'schedule');
+
+    expect(payload.status).toBe('standby');
+    expect(payload.scheduledEventDate).toBeUndefined();
+    // The desired date should still flow through so the date change isn't lost.
+    expect(payload.desiredEventDate).toBe('2026-07-20');
+  });
+
+  it('still sends scheduledEventDate when scheduling AND the date changed', () => {
+    const formData = { ...baseFormData, status: 'scheduled', eventDate: '2026-07-20' };
+    const original = { ...baseFormData, status: 'in_process', eventDate: '2026-06-15' };
+    const eventData = buildEventDataForServer(formData, {
+      mode: 'schedule',
+      hasEventRequest: true,
+      eventRequestStatus: 'in_process',
+      sandwichMode: 'total',
+      actualSandwichMode: 'total',
+    });
+    const payload = detectChangedFields(eventData, original, 'schedule');
+
+    expect(payload.status).toBe('scheduled');
+    expect(payload.scheduledEventDate).toBe('2026-07-20');
+  });
+
   it('falls back to "scheduled" when the form has no status set', () => {
     const formData = { ...baseFormData };
     delete formData.status;

--- a/client/src/components/event-requests/form-utils.ts
+++ b/client/src/components/event-requests/form-utils.ts
@@ -291,12 +291,19 @@ export function detectChangedFields(
   if (mode === 'schedule') {
     const resolvedStatus = eventData.status || 'scheduled';
     filteredEventData.status = resolvedStatus;
-    // Only attach the scheduled date when the event is actually being scheduled.
     if (resolvedStatus === 'scheduled') {
+      // Only attach the scheduled date when the event is actually being scheduled.
       const schedDate = eventData.scheduledEventDate || eventData.desiredEventDate;
       if (schedDate) {
         filteredEventData.scheduledEventDate = schedDate;
       }
+    } else {
+      // The dialog opens in schedule mode, so buildEventDataForServer always populates
+      // scheduledEventDate. If the user instead picks a non-scheduled status (e.g.
+      // Standby) AND changed the date, the change-detection loop above would have added
+      // scheduledEventDate to the payload — sending a confirmed scheduled date alongside
+      // a non-scheduled status. Strip it so the status and date stay consistent.
+      delete filteredEventData.scheduledEventDate;
     }
     // Always include desiredEventDate if it has a value, so the date is never lost.
     if (eventData.desiredEventDate) {


### PR DESCRIPTION
## Problem (caught by Cursor bot review on PR #409)

In `buildEventDataForServer`, schedule mode always populates `scheduledEventDate` (line 58: the condition is true whenever `mode === 'schedule'`, regardless of the chosen status).

If the user opens **Mark Scheduled** but picks a non-scheduled status (e.g. **Standby**) **and also changes the event date**, the change-detection loop in `detectChangedFields` adds `scheduledEventDate` to the payload (because it now differs from the original). The schedule-mode safety block only *adds* `scheduledEventDate` when the status is `scheduled` — it never *removes* it otherwise. Result: a confirmed scheduled date gets sent alongside a non-scheduled status, contradicting intent.

The existing test missed this because it used identical dates for form and original, so the date never registered as "changed".

## Fix

In the schedule-mode block of `detectChangedFields`, when the resolved status is not `scheduled`, explicitly `delete filteredEventData.scheduledEventDate`. The desired-date change still flows through via `desiredEventDate`, so the date edit isn't lost.

## Tests

Added two regression tests (both with a **changed** date, which is what exposed the bug):
- `status = standby` + changed date → `scheduledEventDate` is **not** sent; `desiredEventDate` still is.
- `status = scheduled` + changed date → `scheduledEventDate` **is** sent (no regression to the happy path).

Full suite: 8/8 passing. Type-check clean for touched files.

https://claude.ai/code/session_01RdNWG25SG6nkf1rsFM9LLT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdNWG25SG6nkf1rsFM9LLT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow client-side payload shaping for the scheduling dialog with targeted regression tests; no auth, security, or server contract changes beyond keeping status and dates aligned.
> 
> **Overview**
> Fixes inconsistent **Mark Scheduled** PATCH payloads when the user picks a **non-scheduled** status (e.g. Standby) but also edits the event date.
> 
> In `detectChangedFields` schedule-mode handling, the code now **removes** `scheduledEventDate` from the outgoing payload when the resolved status is not `scheduled`, so change detection cannot send a confirmed scheduled date alongside Standby (or similar). **`desiredEventDate` is still included** so the date change is preserved.
> 
> Regression tests cover standby + changed date (no `scheduledEventDate`, yes `desiredEventDate`) and scheduled + changed date (still sends `scheduledEventDate`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4aa24a02307e33a58500c4f22d9d5b6f9be73f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->