### PR TITLE
Scheduled-event automations (feature-only, conflict-free replacement for #409)

### DIFF
--- a/client/src/components/event-requests/cards/ScheduledCardEnhanced.tsx
+++ b/client/src/components/event-requests/cards/ScheduledCardEnhanced.tsx
@@ -4472,6 +4472,21 @@ export const ScheduledCardEnhanced: React.FC<ScheduledCardEnhancedProps> = ({
               showLabel
             />
 
+            {/* For users who type the event into the Google Sheet by hand instead of
+                using "Push to Sheet" — lets them mark it On Calendar without an actual
+                push. Hidden once the event is already on the calendar. */}
+            {canEdit && !request.addedToOfficialSheet && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={(e) => { e.stopPropagation(); quickToggleBoolean('addedToOfficialSheet', false); }}
+                className="border-[#236383]/30 text-[#236383] hover:bg-[#236383]/10"
+              >
+                <Calendar className="w-4 h-4 mr-1" />
+                Manually Added to Google Sheet
+              </Button>
+            )}
+
             {/* Van needed — only renders when no van flag is set AND no van driver assigned. */}
             {!request.assignedVanDriverId && !request.isDhlVan && (
               <VanNeededBadgeAndButton

--- a/client/src/components/propose-to-sheet-button.tsx
+++ b/client/src/components/propose-to-sheet-button.tsx
@@ -17,6 +17,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { useToast } from '@/hooks/use-toast';
+import { invalidateEventRequestQueries } from '@/lib/queryClient';
 import { FileSpreadsheet, Check, Loader2, ChevronDown, ChevronUp, AlertTriangle, AlertCircle, ArrowRight, RefreshCw, Equal } from 'lucide-react';
 
 interface PushToSheetButtonProps {
@@ -181,6 +182,10 @@ export function PushToSheetButton({
           : `Added new row ${data.rowIndex} to the Planning Sheet.`,
       });
       queryClient.invalidateQueries({ queryKey: ['planning-sheet-preview', eventId] });
+      // The server marks the event addedToOfficialSheet=true on a successful push,
+      // so refresh event-request data too — otherwise the card keeps showing
+      // "Not on Calendar" (and the manual "Added to Google Sheet" button) until reload.
+      invalidateEventRequestQueries(queryClient);
       setShowDialog(false);
     },
     onError: (error: Error) => {

--- a/server/routes/event-requests-legacy.ts
+++ b/server/routes/event-requests-legacy.ts
@@ -2820,8 +2820,15 @@ router.patch(
 
       }
 
-      // Automatically set isConfirmed = true when scheduledEventDate is set
-      if (processedUpdates.scheduledEventDate && !originalEvent.scheduledEventDate) {
+      // Automatically set isConfirmed = true when scheduledEventDate is first set,
+      // UNLESS the client explicitly provided isConfirmed in the same request — an
+      // explicit isConfirmed: false alongside a new date should be respected, not
+      // silently overridden back to true.
+      if (
+        processedUpdates.isConfirmed === undefined &&
+        processedUpdates.scheduledEventDate &&
+        !originalEvent.scheduledEventDate
+      ) {
         processedUpdates.isConfirmed = true;
       }
 

--- a/server/routes/event-requests-legacy.ts
+++ b/server/routes/event-requests-legacy.ts
@@ -2775,6 +2775,20 @@ router.patch(
           processedUpdates.isConfirmed = true;
         }
 
+        // When an event becomes scheduled (or rescheduled to a new confirmed date),
+        // auto-confirm the date ("Date Pending" → "Date Confirmed") and surface it on
+        // the Volunteer Hub so volunteers can sign up. Both remain manually toggleable
+        // afterward; we only set them on the transition, and we never force
+        // showOnVolunteerHub back off. Respect an explicit value sent in the same request.
+        if (toStatus === 'scheduled' || toStatus === 'rescheduled') {
+          if (processedUpdates.isConfirmed === undefined) {
+            processedUpdates.isConfirmed = true;
+          }
+          if (processedUpdates.showOnVolunteerHub === undefined && !originalEvent.showOnVolunteerHub) {
+            processedUpdates.showOnVolunteerHub = true;
+          }
+        }
+
         // Track reason metadata for declined status
         if (processedUpdates.status === 'declined') {
           processedUpdates.declinedAt = new Date();

--- a/server/routes/planning-sheet-proposals.ts
+++ b/server/routes/planning-sheet-proposals.ts
@@ -250,6 +250,26 @@ export function createPlanningSheetProposalsRouter(
       const result = await service.pushEventDirectly(parsedEventId, userId, mergeDecisions);
 
       if (result.success) {
+        // The event is now on the official planning sheet, so mark it "On Calendar".
+        // Only set the timestamp the first time so we preserve when it was originally added.
+        try {
+          const [existing] = await db
+            .select({ addedToOfficialSheet: eventRequests.addedToOfficialSheet })
+            .from(eventRequests)
+            .where(eq(eventRequests.id, parsedEventId));
+          await db
+            .update(eventRequests)
+            .set({
+              addedToOfficialSheet: true,
+              ...(existing?.addedToOfficialSheet ? {} : { addedToOfficialSheetAt: new Date() }),
+              updatedAt: new Date(),
+            })
+            .where(eq(eventRequests.id, parsedEventId));
+        } catch (markError) {
+          // Don't fail the push if the flag update hiccups — the sheet write already succeeded.
+          logger.error(`Pushed event ${parsedEventId} to sheet but failed to mark On Calendar:`, markError);
+        }
+
         res.json({
           success: true,
           message: result.message,

--- a/server/routes/planning-sheet-proposals.ts
+++ b/server/routes/planning-sheet-proposals.ts
@@ -251,17 +251,20 @@ export function createPlanningSheetProposalsRouter(
 
       if (result.success) {
         // The event is now on the official planning sheet, so mark it "On Calendar".
-        // Only set the timestamp the first time so we preserve when it was originally added.
+        // Key the "first time" check off the timestamp itself (not the boolean): older
+        // rows, manual toggles, or partial migrations can have addedToOfficialSheet=true
+        // with a null timestamp, and we want to backfill the timestamp in that case so
+        // the UI doesn't show "On Calendar" without a date.
         try {
           const [existing] = await db
-            .select({ addedToOfficialSheet: eventRequests.addedToOfficialSheet })
+            .select({ addedToOfficialSheetAt: eventRequests.addedToOfficialSheetAt })
             .from(eventRequests)
             .where(eq(eventRequests.id, parsedEventId));
           await db
             .update(eventRequests)
             .set({
               addedToOfficialSheet: true,
-              ...(existing?.addedToOfficialSheet ? {} : { addedToOfficialSheetAt: new Date() }),
+              ...(existing?.addedToOfficialSheetAt ? {} : { addedToOfficialSheetAt: new Date() }),
               updatedAt: new Date(),
             })
             .where(eq(eventRequests.id, parsedEventId));

--- a/server/routes/planning-sheet-proposals.ts
+++ b/server/routes/planning-sheet-proposals.ts
@@ -260,14 +260,30 @@ export function createPlanningSheetProposalsRouter(
             .select({ addedToOfficialSheetAt: eventRequests.addedToOfficialSheetAt })
             .from(eventRequests)
             .where(eq(eventRequests.id, parsedEventId));
-          await db
-            .update(eventRequests)
-            .set({
-              addedToOfficialSheet: true,
-              ...(existing?.addedToOfficialSheetAt ? {} : { addedToOfficialSheetAt: new Date() }),
-              updatedAt: new Date(),
-            })
-            .where(eq(eventRequests.id, parsedEventId));
+          const setTimestamp = !existing?.addedToOfficialSheetAt;
+          try {
+            await db
+              .update(eventRequests)
+              .set({
+                addedToOfficialSheet: true,
+                ...(setTimestamp ? { addedToOfficialSheetAt: new Date() } : {}),
+                updatedAt: new Date(),
+              })
+              .where(eq(eventRequests.id, parsedEventId));
+          } catch (updateError) {
+            // The addedToOfficialSheetAt column may not exist on this branch yet
+            // (migration pending). Mirror the main PATCH path: retry with just the
+            // boolean so "On Calendar" still flips true even if the timestamp can't persist.
+            if (setTimestamp) {
+              logger.warn(`Push mark On Calendar failed with timestamp for event ${parsedEventId}, retrying without it:`, updateError);
+              await db
+                .update(eventRequests)
+                .set({ addedToOfficialSheet: true, updatedAt: new Date() })
+                .where(eq(eventRequests.id, parsedEventId));
+            } else {
+              throw updateError;
+            }
+          }
         } catch (markError) {
           // Don't fail the push if the flag update hiccups — the sheet write already succeeded.
           logger.error(`Pushed event ${parsedEventId} to sheet but failed to mark On Calendar:`, markError);


### PR DESCRIPTION
## Why a new PR

PR #409 became conflicted: it carried both the new features **and** copies of the save-form fixes, but those save-form fixes already merged separately via **#410** and **#411**. The overlap (in `form-utils.ts` and `mark-scheduled-save.test.ts`) is the source of #409's conflicts.

This branch is rebased on current `main` and contains **only the three features that are still missing**, so it merges cleanly. **Please close #409 in favor of this.**

## What's included

1. **Auto-confirm date + auto-add to Volunteer Hub when scheduled** (`server/routes/event-requests-legacy.ts`) — when an event transitions to `scheduled`/`rescheduled`, the PATCH handler defaults `isConfirmed = true` and `showOnVolunteerHub = true`. Respects explicit values sent in the same request; never forces `showOnVolunteerHub` back off. Uses the existing in-scope `toStatus`.

2. **Push to Sheet marks On Calendar** (`server/routes/planning-sheet-proposals.ts`) — after a successful `pushEventDirectly`, sets `addedToOfficialSheet = true` + a first-time `addedToOfficialSheetAt`. A flag-update failure is logged but doesn't fail the push (the sheet write already succeeded).

3. **"Manually Added to Google Sheet" button** (`client/src/components/event-requests/cards/ScheduledCardEnhanced.tsx`) — for hand-entered sheet rows; marks the event On Calendar without an actual push, hidden once it's already on the calendar. Uses the already-imported `Calendar` icon.

## Verification
- All three features confirmed absent from current `main` before applying.
- Type-check: no new errors introduced by these changes (pre-existing repo TS errors unchanged).
- No changes to the save-form files, so no conflict with what #410/#411 already merged.

## Note
Going-forward only — existing already-scheduled events won't retroactively get the volunteer-hub/confirmed flags until next saved (backfill intentionally omitted per earlier decision).

https://claude.ai/code/session_01RdNWG25SG6nkf1rsFM9LLT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdNWG25SG6nkf1rsFM9LLT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches legacy event PATCH defaults and post-push DB updates that affect volunteer visibility and calendar state; failures on flag updates are non-blocking but could leave UI/DB briefly inconsistent until refresh.
> 
> **Overview**
> Adds three scheduled-event workflows that were missing from `main` (clean replacement for conflicted #409).
> 
> When an event moves to **scheduled** or **rescheduled**, the legacy PATCH handler now defaults **`isConfirmed`** and **`showOnVolunteerHub`** on that transition (unless the client sends explicit values; hub visibility is never forced off). Setting a **first** `scheduledEventDate` only auto-confirms the date when **`isConfirmed`** was not sent in the same request.
> 
> After a successful **Push to Sheet**, the server sets **`addedToOfficialSheet`** (and backfills **`addedToOfficialSheetAt`** when missing), with a fallback if the timestamp column is absent; failures are logged but do not undo the sheet write. The push button also **invalidates event-request queries** so the card reflects On Calendar without a full reload.
> 
> On the scheduled card, editors who typed the row into the sheet manually get a **“Manually Added to Google Sheet”** control (hidden once already on calendar) that toggles the same On Calendar flag via the existing quick-toggle path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87053c2a8bede4cf53c45519752c4935ee4a13c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->