### PR TITLE
Claude/keen johnson e lt9m

### DIFF
--- a/client/src/components/stream-chat-rooms.tsx
+++ b/client/src/components/stream-chat-rooms.tsx
@@ -1280,12 +1280,16 @@ export default function StreamChatRooms({ defaultTab }: { defaultTab?: string | 
           </DialogDescription>
         </DialogHeader>
         {(() => {
+          // Total members on the channel (independent of how the current user is filtered out
+          // of the display list, so a 2-person DM can never be mistaken for a group).
+          const totalMemberCount = Object.keys(membersDialogChannel?.state?.members || {}).length;
+
           // Membership can only be edited on group chats (messaging channels with 3+ members),
           // and only by admins/coordinators. Team rooms and DMs are not editable here.
           const isEditableGroup =
             canManageMembers &&
             membersDialogChannel?.type === 'messaging' &&
-            membersDialogUsers.length >= 2;
+            totalMemberCount > 2;
 
           // App user IDs already in the channel (strip the `user_` Stream prefix).
           const currentMemberAppIds = new Set(

--- a/client/src/components/stream-chat-rooms.tsx
+++ b/client/src/components/stream-chat-rooms.tsx
@@ -33,6 +33,9 @@ import {
   X,
   MessageCircle,
   ChevronLeft,
+  Trash2,
+  UserPlus,
+  UserMinus,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -41,6 +44,17 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { hasPermission } from '@shared/unified-auth-utils';
 import { Check, CheckCheck } from 'lucide-react';
 import {
   Tooltip,
@@ -370,12 +384,26 @@ export default function StreamChatRooms({ defaultTab }: { defaultTab?: string | 
   const [showMembersDialog, setShowMembersDialog] = useState(false);
   const [membersDialogTitle, setMembersDialogTitle] = useState<string>('Chat Members');
   const [membersDialogUsers, setMembersDialogUsers] = useState<Array<{ id: string; name: string }>>([]);
-  
+  const [membersDialogChannel, setMembersDialogChannel] = useState<ChannelType | null>(null);
+  const [showAddMembers, setShowAddMembers] = useState(false);
+  const [memberSearch, setMemberSearch] = useState('');
+  const [membersToAdd, setMembersToAdd] = useState<string[]>([]);
+  const [isSavingMembers, setIsSavingMembers] = useState(false);
+
+  // DM deletion (hide-for-me) confirmation
+  const [dmToDelete, setDmToDelete] = useState<ChannelType | null>(null);
+
+  // Permission flags for managing group membership (admins/coordinators only)
+  const canAddMembers = hasPermission(user, PERMISSIONS.CHAT_GROUP_ADD_MEMBERS);
+  const canRemoveMembers = hasPermission(user, PERMISSIONS.CHAT_GROUP_REMOVE_MEMBERS);
+  const canManageMembers = canAddMembers || canRemoveMembers;
+
   // Mobile view: show sidebar (rooms list) or chat
   const [mobileShowSidebar, setMobileShowSidebar] = useState(true);
 
-  const openMembersDialog = (channel: ChannelType) => {
-    const members = Object.values(channel.state?.members || {})
+  // Build the (sorted, current-user-excluded) member list for a channel.
+  const getChannelMemberList = (channel: ChannelType) =>
+    Object.values(channel.state?.members || {})
       .map((m: any) => {
         const id = String(m.user?.id || m.user_id || '');
         const name = String(m.user?.name || m.user_id || m.user?.id || 'Unknown');
@@ -384,9 +412,73 @@ export default function StreamChatRooms({ defaultTab }: { defaultTab?: string | 
       .filter((m) => m.id && m.id !== streamUserId)
       .sort((a, b) => a.name.localeCompare(b.name));
 
-    setMembersDialogUsers(members);
+  const openMembersDialog = (channel: ChannelType) => {
+    setMembersDialogChannel(channel);
+    setMembersDialogUsers(getChannelMemberList(channel));
     setMembersDialogTitle(String((channel.data as any)?.name || 'Chat Members'));
+    setShowAddMembers(false);
+    setMembersToAdd([]);
+    setMemberSearch('');
     setShowMembersDialog(true);
+  };
+
+  // Hide a DM for the current user only (non-destructive; clears their copy of history).
+  const hideDirectMessage = async (channel: ChannelType) => {
+    if (!client || !streamUserId) return;
+    try {
+      // hide(null, clearHistory) hides for the connected user and clears their copy of history
+      await channel.hide(null, true);
+      if (activeChannel?.cid === channel.cid) {
+        setActiveChannel(null);
+        setMobileShowSidebar(true);
+      }
+      await loadUserChannels(client, streamUserId);
+      toast({
+        title: 'Conversation deleted',
+        description: 'It has been removed from your list. It will reappear if a new message is sent.',
+      });
+    } catch (error) {
+      logger.error('Failed to hide DM:', error);
+      toast({
+        title: 'Failed to delete conversation',
+        description: 'Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setDmToDelete(null);
+    }
+  };
+
+  // Add or remove members on an existing group chat via the server (admin-gated).
+  const updateGroupMembers = async (
+    channel: ChannelType,
+    changes: { add?: string[]; remove?: string[] }
+  ) => {
+    if (!client || !streamUserId) return;
+    setIsSavingMembers(true);
+    try {
+      await apiRequest('POST', `/api/stream/channels/${channel.type}/${channel.id}/members`, changes);
+      // Refresh the channel state so the dialog and list reflect the change.
+      await channel.watch();
+      setMembersDialogUsers(getChannelMemberList(channel));
+      setMembersToAdd([]);
+      setMemberSearch('');
+      setShowAddMembers(false);
+      await loadUserChannels(client, streamUserId);
+      toast({
+        title: 'Group updated',
+        description: 'The member list has been updated.',
+      });
+    } catch (error: any) {
+      logger.error('Failed to update group members:', error);
+      toast({
+        title: 'Failed to update group',
+        description: error?.message || 'Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSavingMembers(false);
+    }
   };
 
   // Fetch all users for DM/group creation (uses for-assignments endpoint - no special permissions needed)
@@ -990,6 +1082,19 @@ export default function StreamChatRooms({ defaultTab }: { defaultTab?: string | 
                               {unreadCount}
                             </Badge>
                           )}
+                          <button
+                            type="button"
+                            aria-label={`Delete conversation with ${getDMDisplayName(channel)}`}
+                            title="Delete conversation"
+                            className="p-1 rounded text-gray-400 hover:text-red-600 hover:bg-red-50 transition-colors"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              e.preventDefault();
+                              setDmToDelete(channel);
+                            }}
+                          >
+                            <Trash2 className="w-4 h-4" />
+                          </button>
                         </div>
                       </div>
                     );
@@ -1174,35 +1279,196 @@ export default function StreamChatRooms({ defaultTab }: { defaultTab?: string | 
             {membersDialogUsers.length} member{membersDialogUsers.length === 1 ? '' : 's'}
           </DialogDescription>
         </DialogHeader>
-        <ScrollArea className="max-h-[320px] pr-3">
-          <div className="space-y-2">
-            {membersDialogUsers.map((m) => {
-              const initials = m.name
-                .split(' ')
-                .filter(Boolean)
-                .slice(0, 2)
-                .map((p) => p[0])
-                .join('')
-                .toUpperCase();
+        {(() => {
+          // Membership can only be edited on group chats (messaging channels with 3+ members),
+          // and only by admins/coordinators. Team rooms and DMs are not editable here.
+          const isEditableGroup =
+            canManageMembers &&
+            membersDialogChannel?.type === 'messaging' &&
+            membersDialogUsers.length >= 2;
 
-              return (
-                <div key={m.id} className="flex items-center gap-3 p-2 rounded-md hover:bg-gray-50">
-                  <Avatar className="w-8 h-8">
-                    <AvatarFallback className="bg-[#47B3CB]/20 text-[#007E8C] text-xs">
-                      {initials || 'TM'}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div className="min-w-0">
-                    <div className="text-sm font-medium text-gray-900 truncate">{m.name}</div>
-                    <div className="text-xs text-gray-500 truncate">{m.id}</div>
-                  </div>
+          // App user IDs already in the channel (strip the `user_` Stream prefix).
+          const currentMemberAppIds = new Set(
+            Object.keys(membersDialogChannel?.state?.members || {}).map((sid) =>
+              sid.replace(/^user_/, '')
+            )
+          );
+
+          const addableUsers = allUsers.filter((u: any) => {
+            if (currentMemberAppIds.has(String(u.id))) return false;
+            if (!memberSearch.trim()) return true;
+            const q = memberSearch.toLowerCase();
+            return (
+              u.firstName?.toLowerCase().includes(q) ||
+              u.lastName?.toLowerCase().includes(q) ||
+              u.email?.toLowerCase().includes(q)
+            );
+          });
+
+          return (
+            <>
+              <ScrollArea className="max-h-[280px] pr-3">
+                <div className="space-y-2">
+                  {membersDialogUsers.map((m) => {
+                    const initials = m.name
+                      .split(' ')
+                      .filter(Boolean)
+                      .slice(0, 2)
+                      .map((p) => p[0])
+                      .join('')
+                      .toUpperCase();
+
+                    return (
+                      <div key={m.id} className="flex items-center gap-3 p-2 rounded-md hover:bg-gray-50">
+                        <Avatar className="w-8 h-8">
+                          <AvatarFallback className="bg-[#47B3CB]/20 text-[#007E8C] text-xs">
+                            {initials || 'TM'}
+                          </AvatarFallback>
+                        </Avatar>
+                        <div className="min-w-0 flex-1">
+                          <div className="text-sm font-medium text-gray-900 truncate">{m.name}</div>
+                          <div className="text-xs text-gray-500 truncate">{m.id}</div>
+                        </div>
+                        {isEditableGroup && canRemoveMembers && (
+                          <button
+                            type="button"
+                            aria-label={`Remove ${m.name} from group`}
+                            title="Remove from group"
+                            disabled={isSavingMembers}
+                            className="p-1 rounded text-gray-400 hover:text-red-600 hover:bg-red-50 transition-colors disabled:opacity-50"
+                            onClick={() =>
+                              updateGroupMembers(membersDialogChannel!, {
+                                remove: [m.id.replace(/^user_/, '')],
+                              })
+                            }
+                          >
+                            <UserMinus className="w-4 h-4" />
+                          </button>
+                        )}
+                      </div>
+                    );
+                  })}
                 </div>
-              );
-            })}
-          </div>
-        </ScrollArea>
+              </ScrollArea>
+
+              {isEditableGroup && canAddMembers && (
+                <div className="border-t pt-3 mt-1">
+                  {!showAddMembers ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="w-full border-dashed border-[#47B3CB] text-[#007E8C] hover:bg-[#47B3CB]/10"
+                      onClick={() => setShowAddMembers(true)}
+                    >
+                      <UserPlus className="w-4 h-4 mr-2" />
+                      Add members
+                    </Button>
+                  ) : (
+                    <div className="space-y-3">
+                      <div className="relative">
+                        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+                        <Input
+                          placeholder="Search team members..."
+                          value={memberSearch}
+                          onChange={(e) => setMemberSearch(e.target.value)}
+                          className="pl-10"
+                        />
+                      </div>
+                      <ScrollArea className="h-40">
+                        {addableUsers.length === 0 ? (
+                          <div className="text-center text-gray-500 py-4 text-sm">
+                            No team members to add
+                          </div>
+                        ) : (
+                          addableUsers.map((u: any) => (
+                            <div
+                              key={u.id}
+                              className={`flex items-center gap-3 p-2 rounded-lg cursor-pointer ${
+                                membersToAdd.includes(u.id) ? 'bg-[#47B3CB]/20' : 'hover:bg-gray-100'
+                              }`}
+                              onClick={() =>
+                                setMembersToAdd((prev) =>
+                                  prev.includes(u.id)
+                                    ? prev.filter((id) => id !== u.id)
+                                    : [...prev, u.id]
+                                )
+                              }
+                            >
+                              <Checkbox checked={membersToAdd.includes(u.id)} />
+                              <Avatar className="w-8 h-8">
+                                <AvatarFallback className="bg-[#47B3CB]/20 text-[#007E8C] text-xs">
+                                  {getUserInitials(u)}
+                                </AvatarFallback>
+                              </Avatar>
+                              <div className="flex-1 min-w-0">
+                                <div className="font-medium text-sm truncate">{getUserDisplayName(u)}</div>
+                                <div className="text-xs text-gray-500 truncate">{u.email}</div>
+                              </div>
+                            </div>
+                          ))
+                        )}
+                      </ScrollArea>
+                      <div className="flex gap-2">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="flex-1"
+                          disabled={isSavingMembers}
+                          onClick={() => {
+                            setShowAddMembers(false);
+                            setMembersToAdd([]);
+                            setMemberSearch('');
+                          }}
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          className="flex-1 bg-[#007E8C] hover:bg-[#236383]"
+                          disabled={membersToAdd.length === 0 || isSavingMembers}
+                          onClick={() =>
+                            updateGroupMembers(membersDialogChannel!, { add: membersToAdd })
+                          }
+                        >
+                          <UserPlus className="w-4 h-4 mr-2" />
+                          Add{membersToAdd.length > 0 ? ` (${membersToAdd.length})` : ''}
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </>
+          );
+        })()}
       </DialogContent>
     </Dialog>
+
+    {/* Delete (hide) DM confirmation */}
+    <AlertDialog open={!!dmToDelete} onOpenChange={(open) => !open && setDmToDelete(null)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this conversation?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This removes the conversation{dmToDelete ? ` with ${getDMDisplayName(dmToDelete)}` : ''} from
+            your list and clears your copy of the messages. The other person will still have it, and the
+            conversation will reappear if a new message is sent.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-red-600 hover:bg-red-700"
+            onClick={() => dmToDelete && hideDirectMessage(dmToDelete)}
+          >
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
 
     {/* New Direct Message Dialog */}
     <Dialog open={showNewMessageDialog} onOpenChange={setShowNewMessageDialog}>

--- a/client/src/components/stream-chat-rooms.tsx
+++ b/client/src/components/stream-chat-rooms.tsx
@@ -412,7 +412,15 @@ export default function StreamChatRooms({ defaultTab }: { defaultTab?: string | 
       .filter((m) => m.id && m.id !== streamUserId)
       .sort((a, b) => a.name.localeCompare(b.name));
 
-  const openMembersDialog = (channel: ChannelType) => {
+  const openMembersDialog = async (channel: ChannelType) => {
+    // Channels opened from the sidebar list may not be watched yet, so channel.state.members can
+    // be a partial subset. Watch first so the full member list (and the group-vs-DM member count
+    // used to gate edit controls) is accurate.
+    try {
+      await channel.watch();
+    } catch (error) {
+      logger.error('Failed to load channel members:', error);
+    }
     setMembersDialogChannel(channel);
     setMembersDialogUsers(getChannelMemberList(channel));
     setMembersDialogTitle(String((channel.data as any)?.name || 'Chat Members'));
@@ -468,10 +476,15 @@ export default function StreamChatRooms({ defaultTab }: { defaultTab?: string | 
       await loadUserChannels(client, streamUserId);
 
       if (result?.success === false) {
-        // Partial failure (HTTP 207): some changes may have applied, some did not.
+        // HTTP 207: the mutation failed. If anything committed it's a partial update; if nothing
+        // committed it's an outright failure.
         toast({
-          title: 'Group only partially updated',
-          description: result?.error || 'Some changes could not be applied. Please review the member list.',
+          title: result?.changed ? 'Group only partially updated' : 'Failed to update group',
+          description:
+            result?.error ||
+            (result?.changed
+              ? 'Some changes could not be applied. Please review the member list.'
+              : 'No changes could be applied. Please try again.'),
           variant: 'destructive',
         });
       } else if (result?.changed === false) {

--- a/client/src/components/stream-chat-rooms.tsx
+++ b/client/src/components/stream-chat-rooms.tsx
@@ -457,20 +457,44 @@ export default function StreamChatRooms({ defaultTab }: { defaultTab?: string | 
     if (!client || !streamUserId) return;
     setIsSavingMembers(true);
     try {
-      await apiRequest('POST', `/api/stream/channels/${channel.type}/${channel.id}/members`, changes);
-      // Refresh the channel state so the dialog and list reflect the change.
+      const result = await apiRequest('POST', `/api/stream/channels/${channel.type}/${channel.id}/members`, changes);
+      // Refresh the channel state so the dialog and list reflect the actual result (a partial
+      // failure may still have committed some changes).
       await channel.watch();
       setMembersDialogUsers(getChannelMemberList(channel));
       setMembersToAdd([]);
       setMemberSearch('');
       setShowAddMembers(false);
       await loadUserChannels(client, streamUserId);
-      toast({
-        title: 'Group updated',
-        description: 'The member list has been updated.',
-      });
+
+      if (result?.success === false) {
+        // Partial failure (HTTP 207): some changes may have applied, some did not.
+        toast({
+          title: 'Group only partially updated',
+          description: result?.error || 'Some changes could not be applied. Please review the member list.',
+          variant: 'destructive',
+        });
+      } else if (result?.changed === false) {
+        toast({
+          title: 'No changes',
+          description: 'The member list was already up to date.',
+        });
+      } else {
+        toast({
+          title: 'Group updated',
+          description: 'The member list has been updated.',
+        });
+      }
     } catch (error: any) {
       logger.error('Failed to update group members:', error);
+      // The request failed outright — still refresh so the UI reflects the true state.
+      try {
+        await channel.watch();
+        setMembersDialogUsers(getChannelMemberList(channel));
+        await loadUserChannels(client, streamUserId);
+      } catch (refreshError) {
+        logger.error('Failed to refresh group after error:', refreshError);
+      }
       toast({
         title: 'Failed to update group',
         description: error?.message || 'Please try again.',

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -246,6 +246,27 @@ function MultiViewSidebar({
   );
 }
 
+// Renders the GuidedTour floating help button, but hides it whenever Team Chat
+// ('chat') is one of the currently visible panels. The Stream Chat message/DM
+// reply send button sits at the bottom-right, exactly where the floating help
+// button would otherwise overlap it. This must read the multi-view context
+// (not dashboard's activeSection) because panel navigation in multi-view mode
+// updates the focused panel's section without touching activeSection.
+function GuidedTourGate() {
+  const { panels, activePanel, isMultiViewEnabled } = useMultiView();
+
+  const visibleSections = isMultiViewEnabled
+    ? panels.map((p) => p.section)
+    : [
+        (panels.find((p) => p.id === activePanel) ||
+          panels.find((p) => p.id === 'primary') ||
+          panels[0])?.section,
+      ];
+
+  if (visibleSections.includes('chat')) return null;
+  return <GuidedTour />;
+}
+
 export default function Dashboard({
   initialSection = 'dashboard',
 }: {
@@ -1260,9 +1281,9 @@ export default function Dashboard({
         </div>
         </div>
 
-        {/* Guided Tour System - hidden on Team Chat so the floating help button
-            doesn't overlap the message/DM reply send button (bottom-right) */}
-        {activeSection !== 'chat' && <GuidedTour />}
+        {/* Guided Tour System - hidden on Team Chat (incl. multi-view panels) so the
+            floating help button doesn't overlap the message/DM reply send button */}
+        <GuidedTourGate />
 
         {/* AI Assistant - Only show on sections that don't have their own AI chat */}
         {!['event-requests', 'event-ops-dashboard', 'collections', 'analytics', 'grant-metrics', 'weekly-monitoring', 'event-impact-reports', 'team-board', 'tsp-network', 'projects', 'resources', 'important-links', 'meetings', 'groups-catalog'].includes(activeSection) && (

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1260,8 +1260,9 @@ export default function Dashboard({
         </div>
         </div>
 
-        {/* Guided Tour System */}
-        <GuidedTour />
+        {/* Guided Tour System - hidden on Team Chat so the floating help button
+            doesn't overlap the message/DM reply send button (bottom-right) */}
+        {activeSection !== 'chat' && <GuidedTour />}
 
         {/* AI Assistant - Only show on sections that don't have their own AI chat */}
         {!['event-requests', 'event-ops-dashboard', 'collections', 'analytics', 'grant-metrics', 'weekly-monitoring', 'event-impact-reports', 'team-board', 'tsp-network', 'projects', 'resources', 'important-links', 'meetings', 'groups-catalog'].includes(activeSection) && (

--- a/server/routes/stream.ts
+++ b/server/routes/stream.ts
@@ -268,6 +268,114 @@ streamRoutes.post('/channels', async (req, res) => {
   }
 });
 
+// Add and/or remove members on an existing group chat (messaging channel with 3+ members).
+// Restricted to admins/coordinators via the CHAT_GROUP_ADD_MEMBERS / CHAT_GROUP_REMOVE_MEMBERS
+// permissions. DMs and permission-driven team rooms cannot be edited here.
+streamRoutes.post('/channels/:type/:id/members', async (req, res) => {
+  try {
+    const user = req.user || req.session?.user;
+    if (!user) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+
+    const { type, id } = req.params;
+    const add: string[] = Array.isArray(req.body?.add) ? req.body.add : [];
+    const remove: string[] = Array.isArray(req.body?.remove) ? req.body.remove : [];
+
+    if (add.length === 0 && remove.length === 0) {
+      return res.status(400).json({ error: 'Nothing to change' });
+    }
+
+    // Only group chats (messaging type) can have their membership edited here.
+    if (type !== 'messaging') {
+      return res.status(400).json({ error: 'Only group chats can be edited' });
+    }
+
+    // Permission check (mirrors requirePermission: super_admin/admin pass, otherwise needs the
+    // specific permission). Adding and removing are gated independently.
+    const hasPerm = (permission: string) =>
+      user.role === 'super_admin' ||
+      user.role === 'admin' ||
+      (Array.isArray(user.permissions) && user.permissions.includes(permission));
+
+    if (add.length > 0 && !hasPerm(PERMISSIONS.CHAT_GROUP_ADD_MEMBERS)) {
+      return res.status(403).json({ error: 'You do not have permission to add members' });
+    }
+    if (remove.length > 0 && !hasPerm(PERMISSIONS.CHAT_GROUP_REMOVE_MEMBERS)) {
+      return res.status(403).json({ error: 'You do not have permission to remove members' });
+    }
+
+    if (!streamServerClient) {
+      streamServerClient = initializeStreamServer();
+      if (!streamServerClient) {
+        return res.status(500).json({ error: 'Stream Chat not initialized' });
+      }
+    }
+
+    const streamUserId = `user_${user.id}`;
+    const channel = streamServerClient.channel(type, id);
+    await channel.query({ members: { limit: 200 } });
+
+    const currentMemberIds = Object.keys(channel.state.members || {});
+
+    // Only an admin or an existing member can manage the group.
+    const isAdmin = user.role === 'super_admin' || user.role === 'admin';
+    if (!isAdmin && !currentMemberIds.includes(streamUserId)) {
+      return res.status(403).json({ error: 'You are not a member of this group' });
+    }
+
+    // Guard: this endpoint is for editing existing group chats, not 1:1 DMs.
+    if (currentMemberIds.length <= 2) {
+      return res.status(400).json({ error: 'Member editing is only available for group chats' });
+    }
+
+    // Register any newly added users with Stream before adding them.
+    const addStreamIds: string[] = [];
+    for (const participantId of add) {
+      const participantStreamId = `user_${participantId}`;
+      if (currentMemberIds.includes(participantStreamId)) continue;
+      try {
+        const participantUser = await storage.getUser(participantId);
+        if (participantUser) {
+          await streamServerClient.upsertUser({
+            id: participantStreamId,
+            name: participantUser.firstName && participantUser.lastName
+              ? `${participantUser.firstName} ${participantUser.lastName}`
+              : participantUser.email,
+            email: participantUser.email,
+            role: 'user',
+          });
+        }
+      } catch (upsertError) {
+        logger.error(`Failed to upsert participant ${participantId}:`, upsertError);
+      }
+      addStreamIds.push(participantStreamId);
+    }
+
+    const removeStreamIds = remove
+      .map((p) => `user_${p}`)
+      .filter((sid) => currentMemberIds.includes(sid));
+
+    if (addStreamIds.length > 0) {
+      await channel.addMembers(addStreamIds);
+    }
+    if (removeStreamIds.length > 0) {
+      await channel.removeMembers(removeStreamIds);
+    }
+
+    // Re-query to return the updated member list.
+    await channel.query({ members: { limit: 200 } });
+
+    res.json({
+      success: true,
+      members: Object.keys(channel.state.members || {}),
+    });
+  } catch (error) {
+    logger.error('Channel member update error:', error);
+    res.status(500).json({ error: 'Failed to update members', message: error.message });
+  }
+});
+
 /**
  * Verify Stream Chat webhook signature
  */

--- a/server/routes/stream.ts
+++ b/server/routes/stream.ts
@@ -326,27 +326,31 @@ streamRoutes.post('/channels/:type/:id/members', async (req, res) => {
       return res.status(400).json({ error: 'Member editing is only available for group chats' });
     }
 
-    // Register any newly added users with Stream before adding them.
+    // Register any newly added users with Stream before adding them. Only users that exist
+    // and upsert successfully are queued for addMembers, so a bad/unknown ID can't fail the
+    // whole update or add a non-existent user.
     const addStreamIds: string[] = [];
     for (const participantId of add) {
       const participantStreamId = `user_${participantId}`;
       if (currentMemberIds.includes(participantStreamId)) continue;
       try {
         const participantUser = await storage.getUser(participantId);
-        if (participantUser) {
-          await streamServerClient.upsertUser({
-            id: participantStreamId,
-            name: participantUser.firstName && participantUser.lastName
-              ? `${participantUser.firstName} ${participantUser.lastName}`
-              : participantUser.email,
-            email: participantUser.email,
-            role: 'user',
-          });
+        if (!participantUser) {
+          logger.warn(`Skipping add for unknown user ${participantId}`);
+          continue;
         }
+        await streamServerClient.upsertUser({
+          id: participantStreamId,
+          name: participantUser.firstName && participantUser.lastName
+            ? `${participantUser.firstName} ${participantUser.lastName}`
+            : participantUser.email,
+          email: participantUser.email,
+          role: 'user',
+        });
+        addStreamIds.push(participantStreamId);
       } catch (upsertError) {
-        logger.error(`Failed to upsert participant ${participantId}:`, upsertError);
+        logger.error(`Failed to upsert participant ${participantId}, skipping:`, upsertError);
       }
-      addStreamIds.push(participantStreamId);
     }
 
     const removeStreamIds = remove

--- a/server/routes/stream.ts
+++ b/server/routes/stream.ts
@@ -7,6 +7,7 @@ import { NotificationService } from '../notification-service';
 import { getUserMetadata } from '@shared/types';
 import { requirePermission } from '../middleware/auth';
 import { PERMISSIONS } from '@shared/auth-utils';
+import { hasPermission } from '@shared/unified-auth-utils';
 import { db } from '../db';
 import { notifications } from '@shared/schema';
 import { eq, and } from 'drizzle-orm';
@@ -291,17 +292,13 @@ streamRoutes.post('/channels/:type/:id/members', async (req, res) => {
       return res.status(400).json({ error: 'Only group chats can be edited' });
     }
 
-    // Permission check (mirrors requirePermission: super_admin/admin pass, otherwise needs the
-    // specific permission). Adding and removing are gated independently.
-    const hasPerm = (permission: string) =>
-      user.role === 'super_admin' ||
-      user.role === 'admin' ||
-      (Array.isArray(user.permissions) && user.permissions.includes(permission));
-
-    if (add.length > 0 && !hasPerm(PERMISSIONS.CHAT_GROUP_ADD_MEMBERS)) {
+    // Permission check using the SAME unified logic as the client (hasPermission), so an admin
+    // with an explicit/restricted permissions array is treated identically here and in the UI.
+    // Adding and removing are gated independently.
+    if (add.length > 0 && !hasPermission(user as any, PERMISSIONS.CHAT_GROUP_ADD_MEMBERS)) {
       return res.status(403).json({ error: 'You do not have permission to add members' });
     }
-    if (remove.length > 0 && !hasPerm(PERMISSIONS.CHAT_GROUP_REMOVE_MEMBERS)) {
+    if (remove.length > 0 && !hasPermission(user as any, PERMISSIONS.CHAT_GROUP_REMOVE_MEMBERS)) {
       return res.status(403).json({ error: 'You do not have permission to remove members' });
     }
 

--- a/server/routes/stream.ts
+++ b/server/routes/stream.ts
@@ -357,19 +357,60 @@ streamRoutes.post('/channels/:type/:id/members', async (req, res) => {
       .map((p) => `user_${p}`)
       .filter((sid) => currentMemberIds.includes(sid));
 
-    if (addStreamIds.length > 0) {
-      await channel.addMembers(addStreamIds);
-    }
-    if (removeStreamIds.length > 0) {
-      await channel.removeMembers(removeStreamIds);
+    // Nothing actually resolves to a real change (e.g. all adds were already members or unknown,
+    // all removes were absent). Report changed:false so the client doesn't show a misleading
+    // "Group updated" toast.
+    if (addStreamIds.length === 0 && removeStreamIds.length === 0) {
+      return res.json({
+        success: true,
+        changed: false,
+        added: 0,
+        removed: 0,
+        members: currentMemberIds,
+      });
     }
 
-    // Re-query to return the updated member list.
+    // Stream has no single atomic add+remove call, so apply sequentially and track what actually
+    // committed. On a partial failure we still re-query and return the real member list (with a
+    // 207) instead of a blanket 500, so the client can refresh to the true state.
+    let added = 0;
+    let removed = 0;
+    let opError: any = null;
+    try {
+      if (addStreamIds.length > 0) {
+        await channel.addMembers(addStreamIds);
+        added = addStreamIds.length;
+      }
+      if (removeStreamIds.length > 0) {
+        await channel.removeMembers(removeStreamIds);
+        removed = removeStreamIds.length;
+      }
+    } catch (mutationError: any) {
+      opError = mutationError;
+      logger.error('Channel member mutation partially failed:', mutationError);
+    }
+
+    // Re-query to return the actual resulting member list.
     await channel.query({ members: { limit: 200 } });
+    const members = Object.keys(channel.state.members || {});
+
+    if (opError) {
+      return res.status(207).json({
+        success: false,
+        changed: added > 0 || removed > 0,
+        added,
+        removed,
+        members,
+        error: opError.message || 'Some changes could not be applied',
+      });
+    }
 
     res.json({
       success: true,
-      members: Object.keys(channel.state.members || {}),
+      changed: added > 0 || removed > 0,
+      added,
+      removed,
+      members,
     });
   } catch (error) {
     logger.error('Channel member update error:', error);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New authenticated API mutates Stream channel membership with permission checks; misconfiguration could allow wrong users to edit groups, though DMs and team rooms are explicitly blocked.
> 
> **Overview**
> Adds **Team Chat** management UX on top of Stream: users can **hide/delete a DM** for themselves (with confirmation), and **admins/coordinators** can **add or remove members** on true group chats (3+ people) from the members dialog, gated by `CHAT_GROUP_ADD_MEMBERS` / `CHAT_GROUP_REMOVE_MEMBERS`.
> 
> A new **`POST /api/stream/channels/:type/:id/members`** endpoint applies add/remove on `messaging` channels only, validates permissions with the same `hasPermission` logic as the client, upserts users before add, and returns partial-failure **207** responses so the UI can refresh to the real member list.
> 
> The dashboard now **hides the Guided Tour** floating button whenever **Team Chat** is visible, including in **multi-view**, so it does not overlap Stream’s send control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3df77db91c2cc18c0614c5572fd8392d3ba33c62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->