### PR TITLE
Fix yearly calendar mislabeling last-day-of-school as 'Break'

### DIFF
--- a/client/src/components/monthly-calendar-grid.tsx
+++ b/client/src/components/monthly-calendar-grid.tsx
@@ -199,6 +199,24 @@ function getItemColor(item: TrackedCalendarItem): { bg: string; text: string; bo
   return CATEGORY_COLORS[item.category] || CATEGORY_COLORS.default;
 }
 
+// Detect single-day school markers (last/first day of school, etc.) from the title.
+// These are NOT breaks — e.g. "Last Day of School" marks the start of a district's
+// summer break, not a break period itself. Returns '' when the title is not a marker.
+function getSchoolMarkerType(title: string): string {
+  const t = title.toLowerCase();
+  if (t.includes('last day')) return 'Last Day';
+  if (
+    t.includes('first day') ||
+    t.includes('school starts') ||
+    t.includes('school start') ||
+    t.includes('school resumes')
+  )
+    return '1st Day';
+  if (t.includes('early release') || t.includes('early dismissal')) return 'Early Release';
+  if (t.includes('graduation')) return 'Graduation';
+  return '';
+}
+
 // Get abbreviated break type from title
 function getBreakType(title: string): string {
   const lowerTitle = title.toLowerCase();
@@ -248,6 +266,13 @@ function getItemLabel(item: TrackedCalendarItem): string {
     districtLabel = 'All';
   } else {
     districtLabel = `${districts.length} Dist`;
+  }
+
+  // Single-day school markers (e.g. last/first day of school) take precedence over
+  // break labeling so they aren't mislabeled as a generic "Break".
+  const markerType = getSchoolMarkerType(item.title);
+  if (markerType) {
+    return `${districtLabel} ${markerType}`;
   }
 
   // Add break type context


### PR DESCRIPTION
School day markers like 'Last Day of School' were being rendered in the monthly calendar grid as generic '<District> Break' labels (e.g. 'Fulton Break', '2 Dist Break'). These markers represent the last day of school / start of a district's summer break, not a break period.

Add getSchoolMarkerType() to detect single-day markers (last/first day of school, early release, graduation) by title, and prioritize that over break labeling in getItemLabel() so they display as e.g. 'Fulton Last Day'.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label logic in the monthly calendar grid; no API, auth, or data changes.
> 
> **Overview**
> Fixes **misleading bar labels** on the monthly calendar when tracked school events look like breaks because of title or category heuristics (e.g. *Last Day of School* showing as `Fulton Break`).
> 
> Adds **`getSchoolMarkerType()`** to classify single-day school titles (last/first day, early release, graduation) and runs that check **before** break-type labeling in **`getItemLabel()`**, so bars read like `Fulton Last Day` or `CCS 1st Day` instead of a generic district break name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f80a3b129d635ef8bbbd3a69dc642a054412dd1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->