### PR TITLE
Prevent redundant refetches by ignoring socket echoes from own tab

### DIFF
--- a/client/src/components/event-requests/CallNotesScratchpadDialog.tsx
+++ b/client/src/components/event-requests/CallNotesScratchpadDialog.tsx
@@ -134,6 +134,31 @@ export function CallNotesScratchpadDialog({
           ...(prev || {}),
           ...updatedEvent,
         }));
+
+        // Keep cached list views in sync WITHOUT a full refetch. This dialog
+        // auto-saves every 5s, so a nuclear invalidate here would cause a
+        // refetch storm — and since the originating tab now ignores its own
+        // socket echo, the list won't refresh on its own. Patch the changed
+        // event into any cached list query by id (no-op if its shape doesn't
+        // match or the event isn't present).
+        queryClient.setQueriesData(
+          {
+            predicate: (query) =>
+              Array.isArray(query.queryKey) &&
+              query.queryKey[0] === '/api/event-requests/list',
+          },
+          (data: any) => {
+            if (!data) return data;
+            const patchArray = (arr: any[]) =>
+              arr.map((item) =>
+                item?.id === variables.id ? { ...item, ...updatedEvent } : item
+              );
+            if (Array.isArray(data)) return patchArray(data);
+            if (Array.isArray(data?.requests)) return { ...data, requests: patchArray(data.requests) };
+            if (Array.isArray(data?.items)) return { ...data, items: patchArray(data.items) };
+            return data;
+          }
+        );
       }
       setSyncedAt(new Date());
       setSyncError('');

--- a/client/src/components/event-requests/IntakeCallDialog.tsx
+++ b/client/src/components/event-requests/IntakeCallDialog.tsx
@@ -43,7 +43,8 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
-import { apiRequest } from '@/lib/queryClient';
+import { useQueryClient } from '@tanstack/react-query';
+import { apiRequest, invalidateEventRequestQueries } from '@/lib/queryClient';
 import {
   parseDateOnly,
   toDateOnlyString,
@@ -331,6 +332,7 @@ const IntakeCallDialog: React.FC<IntakeCallDialogProps> = ({
   onCallComplete,
 }) => {
   const { toast } = useToast();
+  const queryClient = useQueryClient();
   const isMobile = useIsMobile();
   const [checkedItems, setCheckedItems] = useState<Set<string>>(new Set());
   const [itemAnswers, setItemAnswers] = useState<Record<string, string>>({});
@@ -716,6 +718,9 @@ const IntakeCallDialog: React.FC<IntakeCallDialogProps> = ({
         nonEventReason: 'Sandwich count under 200 — directed to host finder.',
         nonEventAt: new Date().toISOString(),
       });
+      // Refresh the list ourselves — this dialog no longer relies on the socket
+      // echo (the originating tab now ignores its own echo).
+      await invalidateEventRequestQueries(queryClient);
       clearDraft(`intake:${eventRequest.id}`);
       toast({
         title: 'Moved to Non-Event',
@@ -992,6 +997,12 @@ const IntakeCallDialog: React.FC<IntakeCallDialogProps> = ({
       }
 
       await apiRequest('PATCH', `/api/event-requests/${eventRequest?.id}`, updates);
+
+      // Refresh the list ourselves. Previously the "Save notes" path (without
+      // marking the call complete) relied on the socket echo to refresh; now
+      // that the originating tab ignores its own echo, we invalidate here so the
+      // saved notes/structured fields show up immediately.
+      await invalidateEventRequestQueries(queryClient);
 
       // Build a toast that tells the operator exactly which structured fields
       // got mapped to columns and which inputs couldn't be parsed (those still

--- a/client/src/hooks/useEventRequestSocket.ts
+++ b/client/src/hooks/useEventRequestSocket.ts
@@ -30,6 +30,19 @@ export function useEventRequestSocket() {
     };
 
     const handleEventUpdated = (eventRequest: any) => {
+      // Ignore the echo of our OWN save. Every mutation already refreshes the UI
+      // locally (invalidate in onSuccess/onSettled), so re-invalidating here just
+      // triggers a redundant full refetch that can reset an open form mid-edit.
+      // Updates from other users/tabs/background sync carry a different socket id
+      // (or none) and still refresh exactly as before.
+      if (
+        eventRequest?.originSocketId &&
+        socket.id &&
+        eventRequest.originSocketId === socket.id
+      ) {
+        logger.log('[EventRequestSocket] Ignoring own update echo for', eventRequest.id);
+        return;
+      }
       logger.log('[EventRequestSocket] Event request updated:', eventRequest.id);
       invalidateEventRequestQueries(queryClient);
     };

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,5 +1,6 @@
 import { QueryClient, QueryFunction } from '@tanstack/react-query';
 import { logger } from '@/lib/logger';
+import { getSocketInstance } from '@/lib/socket-singleton';
 
 /**
  * Custom error class that preserves server response details.
@@ -67,7 +68,17 @@ export async function apiRequest(
   }
   
   const isFormData = body instanceof FormData;
-  
+
+  // Tag every request with this browser tab's Socket.IO id. The server echoes
+  // it back on real-time broadcasts so the originating tab can ignore its OWN
+  // echo instead of triggering a redundant full refetch (which can reset an
+  // open form mid-edit). Fails safe: if the socket isn't connected yet the
+  // header is simply omitted and the old refetch-on-echo behavior applies.
+  const socketId = getSocketInstance()?.id;
+  const headers: Record<string, string> = {};
+  if (!isFormData && body) headers['Content-Type'] = 'application/json';
+  if (socketId) headers['X-Socket-Id'] = socketId;
+
   // Create an AbortController for timeout handling
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
@@ -76,11 +87,7 @@ export async function apiRequest(
     logger.log('🚀 [apiRequest] Sending fetch request...');
     const res = await fetch(url, {
       method,
-      headers: isFormData
-        ? {}
-        : body
-          ? { 'Content-Type': 'application/json' }
-          : {},
+      headers,
       body: isFormData ? body : body ? JSON.stringify(body) : undefined,
       credentials: 'include',
       signal: controller.signal,

--- a/server/routes/event-requests/index.ts
+++ b/server/routes/event-requests/index.ts
@@ -62,7 +62,14 @@ router.use('/:id', (req, res, next) => {
     // Only emit for successful responses (2xx) that return an event request object
     if (res.statusCode >= 200 && res.statusCode < 300 && body && body.id) {
       try {
-        emitEventRequestUpdate('event_request_updated', { id: body.id });
+        // Pass through the originating tab's socket id (sent by apiRequest as
+        // X-Socket-Id) so that tab can ignore its own echo. Other users/tabs
+        // and background processes won't match and still refresh as before.
+        const originSocketId = req.headers['x-socket-id'];
+        emitEventRequestUpdate('event_request_updated', {
+          id: body.id,
+          originSocketId: typeof originSocketId === 'string' ? originSocketId : undefined,
+        });
       } catch (e) {
         // Don't let socket errors break the response
         logger.warn('Failed to emit event request update via socket:', e);


### PR DESCRIPTION
## Summary
This PR eliminates redundant full refetches when a tab receives its own socket echo after making mutations. The originating tab now tags requests with its Socket.IO id, the server echoes it back, and the client ignores updates that match its own id. This prevents form resets mid-edit while preserving real-time updates from other users/tabs.

## Key Changes

- **Client request tagging** (`client/src/lib/queryClient.ts`):
  - Import Socket.IO singleton and extract the current tab's socket id
  - Add `X-Socket-Id` header to all API requests (when socket is connected)
  - Refactored header construction for clarity

- **Server echo passthrough** (`server/routes/event-requests/index.ts`):
  - Extract `X-Socket-Id` from request headers
  - Pass `originSocketId` through the socket broadcast payload
  - Allows clients to identify their own updates

- **Client echo filtering** (`client/src/hooks/useEventRequestSocket.ts`):
  - Check if incoming `event_request_updated` event matches the current tab's socket id
  - Skip invalidation for own echoes (prevents redundant refetch)
  - Other users/tabs/background processes still trigger refreshes as before

- **Explicit invalidation in IntakeCallDialog** (`client/src/components/event-requests/IntakeCallDialog.tsx`):
  - Call `invalidateEventRequestQueries()` after "Moved to Non-Event" action
  - Call `invalidateEventRequestQueries()` after "Save notes" action
  - These paths previously relied on socket echo to refresh; now explicitly refresh since the echo is ignored

## Implementation Details

The solution is fail-safe: if the socket isn't connected yet, the `X-Socket-Id` header is simply omitted and the old refetch-on-echo behavior applies. The socket id comparison is strict (both must exist and match exactly) to avoid accidentally filtering legitimate updates.

This change improves UX for operators editing forms in the intake dialog—their edits no longer get interrupted by redundant refetches triggered by their own saves.

https://claude.ai/code/session_01GwCxdLZ58uWtVqNFjA8TUc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches real-time sync for all event-request PATCH/PUT flows; missed invalidation or list-cache patching could leave stale list UI in the originating tab until manual refresh.
> 
> **Overview**
> Stops **redundant full refetches** when a tab saves an event request: the tab that made the change no longer treats its own Socket.IO `event_request_updated` as a signal to invalidate everything, which was resetting open intake/scratchpad forms mid-edit.
> 
> **End-to-end tagging:** `apiRequest` sends `X-Socket-Id` when the socket is connected; successful PATCH/PUT responses broadcast `originSocketId` on the update event; `useEventRequestSocket` skips invalidation when `originSocketId` matches the current tab. Other tabs and background updates still invalidate as before; if the header is missing, behavior falls back to refetch-on-echo.
> 
> **Compensating UI updates** where list views used to refresh only from that echo: **Intake Call** explicitly calls `invalidateEventRequestQueries` after save and “Move to Non-Event”; **Call Notes scratchpad** patches cached `/api/event-requests/list` queries on each 5s autosave instead of invalidating (avoids a refetch storm).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13f049395a09fd6d9a88d5d80261776b2a8701c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->