### PR TITLE
Remove false "someone else edited this" conflicts + fix Move to Non-Event

### DIFF
--- a/client/src/components/event-requests/IntakeCallDialog.tsx
+++ b/client/src/components/event-requests/IntakeCallDialog.tsx
@@ -726,7 +726,10 @@ const IntakeCallDialog: React.FC<IntakeCallDialogProps> = ({
         title: 'Moved to Non-Event',
         description: 'The request was marked as Non-Event. Directed the organizer to the host finder.',
       });
-      onCallComplete?.();
+      // NOTE: deliberately do NOT call onCallComplete() here. The parent's
+      // onCallComplete patches status to 'in_process', which would immediately
+      // undo the Non-Event move. "Move to Non-Event" must always leave the
+      // event in non_event status.
       onClose();
     } catch (error: any) {
       toast({

--- a/server/routes/event-requests-legacy.ts
+++ b/server/routes/event-requests-legacy.ts
@@ -2634,30 +2634,24 @@ router.patch(
         }
       }
 
-      // Extract and remove optimistic locking field from updates before processing
-      const expectedVersion = updates._expectedVersion;
+      // Row-level optimistic locking REMOVED for the normal edit path.
+      // The old _expectedVersion check returned 409 whenever updatedAt changed
+      // AT ALL since the client loaded the event — which fired far more false
+      // "someone else edited this" errors than it ever prevented real conflicts.
+      // The common triggers were the SAME operator (their scratchpad auto-save
+      // bumping updatedAt, the Google Sheets message-backfill, or two quick
+      // edits in a row), not a second person. For this mostly single-editor
+      // intake workflow, blocking the whole save in those cases was net-harmful.
+      // We still strip the field so it's never written as a column. If genuine
+      // concurrent co-editing ever becomes a real problem, add a FIELD-LEVEL
+      // check here (conflict only when the same field changed) rather than
+      // reinstating the row-level gate.
       delete updates._expectedVersion;
 
       // Get original data for audit logging
       logger.info(`[PATCH /:id] About to fetch event ${id} from storage`);
       const originalEvent = await storage.getEventRequestById(id);
       logger.info(`[PATCH /:id] Storage returned:`, originalEvent ? `Event found (${originalEvent.organizationName})` : 'null/undefined');
-
-      // Optimistic locking: if the client sent _expectedVersion, verify the event
-      // hasn't been modified by someone else since they loaded it.
-      // This prevents silent overwrites when two users edit the same event.
-      if (expectedVersion && originalEvent?.updatedAt) {
-        const clientVersion = new Date(expectedVersion).getTime();
-        const serverVersion = new Date(originalEvent.updatedAt).getTime();
-        if (clientVersion !== serverVersion) {
-          logger.warn(`[PATCH /:id] Optimistic lock conflict for event ${id}: client version ${new Date(expectedVersion).toISOString()} vs server version ${new Date(originalEvent.updatedAt).toISOString()}`);
-          return res.status(409).json({
-            message: 'This event was modified by another user while you were editing. Please refresh and try again.',
-            error: 'CONFLICT',
-            serverVersion: originalEvent.updatedAt,
-          });
-        }
-      }
 
       if (!originalEvent) {
         logger.error(`[PATCH /:id] Event request ${id} not found in database`);


### PR DESCRIPTION
## What this does

Two small, independent fixes for the event-requests feature (each its own commit).

### 1. Fix: "Move to Non-Event" must stay `non_event`
`handleMoveToNonEvent` set the status to `non_event`, then called `onCallComplete()` — which patched status straight to `in_process`, immediately undoing the move. Confirmed with the product owner: Move to Non-Event must always leave the event in `non_event`. Removed the follow-on transition.

### 2. Remove the row-level optimistic version gate on `PATCH /api/event-requests/:id`
The `_expectedVersion` check returned `409 "This event was modified by another user while you were editing"` whenever `updatedAt` changed at all since the client loaded the event. In practice the trigger was almost always the **same operator** — their call-notes scratchpad auto-save bumping `updatedAt`, the Google Sheets `message` backfill, or two quick edits in a row — not a real second editor. For this mostly single-editor intake workflow it produced far more false conflicts than real protection, and it blocked the entire save even when edits didn't overlap.

This removes the row-level 409 gate. It still strips `_expectedVersion` so the field is never written as a column.

## Scope / safety
- The separate real-time field-collaboration system (`socket-collaboration.ts`) is **untouched** — it has its own field-level locking and is a different feature.
- Reversible: the client-side conflict-handling code remains (now inert); re-enabling the gate is a one-spot change.
- If genuine concurrent co-editing ever becomes a real problem, the right follow-up is a **field-level** check (conflict only when the same field changed), not the old row-level gate.

## How to test
- Open the edit form **and** the call-notes scratchpad on the same event; let the scratchpad auto-save; then save the form. Previously this 409'd — now it should save.
- Click **Move to Non-Event** and confirm the event lands on (and stays) Non-Event.

## Out of scope (still on the list, not made worse)
Partial saves dropping fields, nuclear cache invalidation on your own save, and the multiple status-change paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwCxdLZ58uWtVqNFjA8TUc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes last-write-wins protection on a core intake PATCH path; status workflow fix is localized but affects how operators classify under-200 requests.
> 
> **Overview**
> **Move to Non-Event** now stays on `non_event`: after the PATCH that marks the request non-event, the intake dialog no longer calls the parent `onCallComplete` callback, which was patching status back to `in_process`.
> 
> **Event request edits** no longer fail with a 409 when `updatedAt` changed since load: the `PATCH /api/event-requests/:id` handler still strips `_expectedVersion` from the body but no longer compares it to the row and blocks the save. Saves proceed even when scratchpad auto-save, sheets backfill, or back-to-back edits bumped `updatedAt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c2ff41fdf2c9719c631ab65bf5cb5408bc32b7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->