### PR TITLE
Centralize event-list projection + fix Non-Event card fields (B9 part 1)

### DIFF
--- a/server/routes/event-requests-legacy.ts
+++ b/server/routes/event-requests-legacy.ts
@@ -1264,10 +1264,12 @@ router.get(
  *   - IntakeCallDialog.tsx
  *
  * NOTE: The field list now lives in ONE place — shared/event-list-projection.ts
- * (`toLightweightEventRequest`). The client derives `LightweightEventRequest`
- * from it, so the server payload and the client type cannot drift. Add new list
- * fields there, once; TypeScript will flag any card that reads a field the
- * projection omits. The notes below are kept for historical reference only.
+ * (`toLightweightEventRequest`), which also exports `LightweightEventRequest`.
+ * Once the client adopts that type, the server payload and client type can no
+ * longer drift (TypeScript would flag a card reading a field the projection
+ * omits). That client adoption is deferred for now; today this just centralizes
+ * the shape. Add new list fields in the projection. The notes below are kept for
+ * historical reference only.
  *
  * FIELD REQUIREMENTS BY COMPONENT:
  *   - ALL CARDS: id, organizationName, department, status, scheduledEventDate,
@@ -1407,10 +1409,11 @@ router.get(
       }
 
       // Map to the lightweight list shape. SINGLE SOURCE OF TRUTH:
-      // shared/event-list-projection.ts — the same function also drives the
-      // client's LightweightEventRequest type, so the server payload and the
-      // client type cannot drift (this was "Cause B": a field a card read but
-      // the list didn't send rendered blank). Add new list fields there, once.
+      // shared/event-list-projection.ts — it also exports LightweightEventRequest.
+      // Once the client adopts that type, the server payload and client type can
+      // no longer drift (this was "Cause B": a field a card read but the list
+      // didn't send rendered blank). Client adoption is deferred; for now this
+      // centralizes the shape. Add new list fields in the projection.
       const lightweightEvents = eventRequests.map((event) =>
         toLightweightEventRequest(event as any)
       );

--- a/server/routes/event-requests-legacy.ts
+++ b/server/routes/event-requests-legacy.ts
@@ -17,6 +17,7 @@ import { hasPermission } from '@shared/unified-auth-utils';
 import { parseDateOnly, getTodayString, toDateOnlyString } from '@shared/date-utils';
 import { isValidTransition, getTransitionError, type EventStatus } from '@shared/event-status-workflow';
 import { parseSandwichCountInput } from '@shared/sandwich-count-utils';
+import { toLightweightEventRequest } from '@shared/event-list-projection';
 import { requirePermission } from '../middleware/auth';
 import { isAuthenticated } from '../auth';
 import { getEventRequestsGoogleSheetsService } from '../google-sheets-event-requests-sync';
@@ -1262,10 +1263,11 @@ router.get(
  *   - ScheduledSpreadsheetView.tsx
  *   - IntakeCallDialog.tsx
  *
- * RULES:
- *   1. If you modify ANY of those components to use a new field, you MUST add it here.
- *   2. If you add a field here, document which component needs it in the comments below.
- *   3. Do NOT remove fields without checking all consuming components.
+ * NOTE: The field list now lives in ONE place — shared/event-list-projection.ts
+ * (`toLightweightEventRequest`). The client derives `LightweightEventRequest`
+ * from it, so the server payload and the client type cannot drift. Add new list
+ * fields there, once; TypeScript will flag any card that reads a field the
+ * projection omits. The notes below are kept for historical reference only.
  *
  * FIELD REQUIREMENTS BY COMPONENT:
  *   - ALL CARDS: id, organizationName, department, status, scheduledEventDate,
@@ -1404,148 +1406,14 @@ router.get(
         eventRequests = eventRequests.filter(event => event.isCorporatePriority === true);
       }
 
-      // Map to lightweight format - see FIELD CONTRACT comment above
-      const lightweightEvents = eventRequests.map(event => ({
-        // ========== IDENTITY ==========
-        id: event.id,
-
-        // ========== ORGANIZATION (All cards) ==========
-        organizationName: event.organizationName,
-        organizationCategory: event.organizationCategory,
-        department: event.department,
-        partnerOrganizations: event.partnerOrganizations, // All cards
-
-        // ========== CONTACT (All cards, IntakeCallDialog) ==========
-        firstName: event.firstName,
-        lastName: event.lastName,
-        email: event.email,
-        phone: event.phone,
-        // Backup contact (NewRequestCard, CompletedCard)
-        backupContactFirstName: (event as any).backupContactFirstName,
-        backupContactLastName: (event as any).backupContactLastName,
-        backupContactEmail: (event as any).backupContactEmail,
-        backupContactPhone: (event as any).backupContactPhone,
-        backupContactRole: (event as any).backupContactRole,
-
-        // ========== DATES (All cards) ==========
-        desiredEventDate: event.desiredEventDate,
-        scheduledEventDate: event.scheduledEventDate,
-        isConfirmed: event.isConfirmed,
-        backupDates: event.backupDates, // NewRequestCard
-
-        // ========== STATUS & WORKFLOW ==========
-        status: event.status,
-        statusChangedAt: event.statusChangedAt,
-        assignedTo: event.assignedTo,
-        nextAction: event.nextAction, // NewRequestCard
-        message: event.message, // NewRequestCard
-        scheduledCallDate: event.scheduledCallDate, // InProcessCard - scheduled call with organizer
-
-        // ========== LOCATION (ScheduledCard, NewRequestCard) ==========
-        eventAddress: event.eventAddress,
-        latitude: event.latitude,
-        longitude: event.longitude,
-
-        // ========== SANDWICH COUNTS & TYPES ==========
-        estimatedSandwichCount: event.estimatedSandwichCount,
-        estimatedSandwichCountMin: event.estimatedSandwichCountMin, // ScheduledCard
-        estimatedSandwichCountMax: event.estimatedSandwichCountMax, // ScheduledCard
-        estimatedSandwichRangeType: event.estimatedSandwichRangeType, // ScheduledCard
-        actualSandwichCount: event.actualSandwichCount,
-        sandwichTypes: event.sandwichTypes, // NewRequestCard, ScheduledCard, CompletedCard
-        hasRefrigeration: event.hasRefrigeration, // RefrigerationWarningBadge on all cards
-        volunteerCount: event.volunteerCount,
-        actualAttendance: event.actualAttendance,
-        estimatedAttendance: event.estimatedAttendance,
-        attendanceAdults: event.attendanceAdults,
-        attendanceTeens: event.attendanceTeens,
-        attendanceKids: event.attendanceKids,
-
-        // ========== DRIVER STAFFING ==========
-        driversNeeded: event.driversNeeded,
-        assignedDriverIds: event.assignedDriverIds,
-        driverDetails: event.driverDetails,
-        selfTransport: event.selfTransport,
-        tentativeDriverIds: event.tentativeDriverIds,
-
-        // ========== SPEAKER STAFFING ==========
-        speakersNeeded: event.speakersNeeded,
-        assignedSpeakerIds: event.assignedSpeakerIds,
-        tentativeSpeakerIds: event.tentativeSpeakerIds,
-        speakerDetails: event.speakerDetails,
-
-        // ========== VOLUNTEER STAFFING ==========
-        volunteersNeeded: event.volunteersNeeded,
-        assignedVolunteerIds: event.assignedVolunteerIds,
-        tentativeVolunteerIds: event.tentativeVolunteerIds,
-        volunteerDetails: event.volunteerDetails,
-
-        // ========== VAN DRIVER ==========
-        vanDriverNeeded: event.vanDriverNeeded,
-        assignedVanDriverId: event.assignedVanDriverId,
-        isDhlVan: event.isDhlVan,
-        customVanDriverName: event.customVanDriverName, // ScheduledCardEnhanced
-
-        // ========== TSP CONTACT (All cards) ==========
-        tspContact: event.tspContact, // Actual user ID
-        tspContactAssigned: event.tspContactAssigned, // Display name
-        customTspContact: event.customTspContact,
-        tspContactAssignedDate: event.tspContactAssignedDate,
-
-        // ========== TOOLKIT STATUS ==========
-        toolkitSent: event.toolkitSent,
-        toolkitStatus: event.toolkitStatus,
-
-        // ========== TIMES (ScheduledCard, EventEditDialog) ==========
-        eventStartTime: event.eventStartTime,
-        eventEndTime: event.eventEndTime,
-        pickupTime: event.pickupTime,
-        pickupDateTime: event.pickupDateTime,
-        pickupTimeWindow: event.pickupTimeWindow, // EventEditDialog
-
-        // ========== TRACKING FLAGS ==========
-        addedToOfficialSheet: event.addedToOfficialSheet,
-        addedToOfficialSheetAt: event.addedToOfficialSheetAt,
-        showOnVolunteerHub: (event as any).showOnVolunteerHub, // ScheduledCardEnhanced badge
-        isUnresponsive: event.isUnresponsive,
-        contactAttempts: event.contactAttempts,
-        lastContactAttempt: event.lastContactAttempt, // NewRequestCard
-        hasHostedBefore: event.previouslyHosted === 'yes', // Computed from previouslyHosted column
-        previouslyHosted: event.previouslyHosted, // Raw value: 'yes', 'no', 'i_dont_know'
-
-        // ========== NOTES (ScheduledCard, ScheduledCardEnhanced) ==========
-        planningNotes: event.planningNotes,
-        schedulingNotes: event.schedulingNotes,
-        contactAttemptsLog: event.contactAttemptsLog,
-        unresponsiveNotes: event.unresponsiveNotes,
-        followUpNotes: event.followUpNotes,
-        distributionNotes: event.distributionNotes,
-        duplicateNotes: event.duplicateNotes,
-        socialMediaPostNotes: event.socialMediaPostNotes,
-        socialMediaPostRequested: event.socialMediaPostRequested,
-        socialMediaPostRequestedDate: event.socialMediaPostRequestedDate,
-        socialMediaPostCompleted: event.socialMediaPostCompleted,
-        socialMediaPostCompletedDate: event.socialMediaPostCompletedDate,
-        socialMediaPostLink: event.socialMediaPostLink,
-
-        // ========== RECIPIENT ALLOCATION (ScheduledCard, SpreadsheetView) ==========
-        assignedRecipientIds: event.assignedRecipientIds,
-        recipientAllocations: event.recipientAllocations, // ScheduledCardEnhanced
-
-        // ========== SPECIAL FLAGS ==========
-        isMlkDayEvent: event.isMlkDayEvent, // ScheduledCardEnhanced
-        isCorporatePriority: event.isCorporatePriority, // EventEditDialog, CorporatePriorityBadge
-        externalId: event.externalId, // ScheduledCard
-        overnightHoldingLocation: event.overnightHoldingLocation, // ScheduledCard
-
-        // ========== POSTPONEMENT (PostponedCard) ==========
-        tentativeNewDate: event.tentativeNewDate,
-        postponementReason: event.postponementReason,
-
-        // ========== TIMESTAMPS ==========
-        createdAt: event.createdAt,
-        updatedAt: event.updatedAt,
-      }));
+      // Map to the lightweight list shape. SINGLE SOURCE OF TRUTH:
+      // shared/event-list-projection.ts — the same function also drives the
+      // client's LightweightEventRequest type, so the server payload and the
+      // client type cannot drift (this was "Cause B": a field a card read but
+      // the list didn't send rendered blank). Add new list fields there, once.
+      const lightweightEvents = eventRequests.map((event) =>
+        toLightweightEventRequest(event as any)
+      );
 
       logger.info(`📋 List endpoint returning ${lightweightEvents.length} lightweight events`);
       res.json(lightweightEvents);

--- a/shared/event-list-projection.ts
+++ b/shared/event-list-projection.ts
@@ -3,15 +3,19 @@ import type { EventRequest } from './schema';
 /**
  * Single source of truth for the lightweight event-list projection.
  *
- * `GET /api/event-requests/list` returns exactly this shape, and the client
- * types the list query as `LightweightEventRequest`
- * (`ReturnType<typeof toLightweightEventRequest>`). Because the server payload
- * and the client type are both derived from this one function, they cannot
- * drift — which is what caused "Cause B": a field a card read but the list
- * didn't send rendered blank on the card even though it saved fine.
+ * `GET /api/event-requests/list` returns exactly this shape. The exported
+ * `LightweightEventRequest` type (`ReturnType<typeof toLightweightEventRequest>`)
+ * is derived from it. Once the client types the list query / card props as
+ * `LightweightEventRequest`, the server payload and the client type can no
+ * longer drift — a field a card reads but the list doesn't send would become a
+ * compile error instead of a blank card ("Cause B").
  *
- * To expose a new field to the cards: add it here, once. TypeScript will then
- * flag any card that reads a field this projection does not include.
+ * NOTE: that client-side adoption is NOT wired up yet (deferred — it's entangled
+ * with schema type debt; see PR notes). Today this centralizes the list shape in
+ * one place and fixes known drift; it does not yet enforce the contract at
+ * compile time.
+ *
+ * To expose a new field to the cards: add it here, once.
  *
  * Keep this a pure projection (field copies + the few documented computed
  * fields). Anything heavier belongs in the full-record endpoint.
@@ -32,11 +36,11 @@ export function toLightweightEventRequest(event: EventRequest) {
     lastName: event.lastName,
     email: event.email,
     phone: event.phone,
-    backupContactFirstName: (event as any).backupContactFirstName,
-    backupContactLastName: (event as any).backupContactLastName,
-    backupContactEmail: (event as any).backupContactEmail,
-    backupContactPhone: (event as any).backupContactPhone,
-    backupContactRole: (event as any).backupContactRole,
+    backupContactFirstName: event.backupContactFirstName,
+    backupContactLastName: event.backupContactLastName,
+    backupContactEmail: event.backupContactEmail,
+    backupContactPhone: event.backupContactPhone,
+    backupContactRole: event.backupContactRole,
 
     // ========== DATES (All cards) ==========
     desiredEventDate: event.desiredEventDate,
@@ -93,6 +97,7 @@ export function toLightweightEventRequest(event: EventRequest) {
 
     // ========== VAN DRIVER ==========
     vanDriverNeeded: event.vanDriverNeeded,
+    vanNeededLikely: event.vanNeededLikely, // read by InProcess/Scheduled cards — was missing from the list (live Cause B)
     assignedVanDriverId: event.assignedVanDriverId,
     isDhlVan: event.isDhlVan,
     customVanDriverName: event.customVanDriverName,
@@ -117,7 +122,7 @@ export function toLightweightEventRequest(event: EventRequest) {
     // ========== TRACKING FLAGS ==========
     addedToOfficialSheet: event.addedToOfficialSheet,
     addedToOfficialSheetAt: event.addedToOfficialSheetAt,
-    showOnVolunteerHub: (event as any).showOnVolunteerHub,
+    showOnVolunteerHub: event.showOnVolunteerHub,
     isUnresponsive: event.isUnresponsive,
     contactAttempts: event.contactAttempts,
     lastContactAttempt: event.lastContactAttempt,
@@ -157,10 +162,10 @@ export function toLightweightEventRequest(event: EventRequest) {
     // Added with the §B9 projection: these were read by NonEventCard but were
     // missing from the old hand-maintained mapper, so the reason/notes rendered
     // blank on Non-Event cards (a live "Cause B" instance).
-    nonEventReason: (event as any).nonEventReason,
-    nonEventNotes: (event as any).nonEventNotes,
-    nonEventBy: (event as any).nonEventBy,
-    nonEventAt: (event as any).nonEventAt,
+    nonEventReason: event.nonEventReason,
+    nonEventNotes: event.nonEventNotes,
+    nonEventBy: event.nonEventBy,
+    nonEventAt: event.nonEventAt,
 
     // ========== TIMESTAMPS ==========
     createdAt: event.createdAt,

--- a/shared/event-list-projection.ts
+++ b/shared/event-list-projection.ts
@@ -1,0 +1,175 @@
+import type { EventRequest } from './schema';
+
+/**
+ * Single source of truth for the lightweight event-list projection.
+ *
+ * `GET /api/event-requests/list` returns exactly this shape, and the client
+ * types the list query as `LightweightEventRequest`
+ * (`ReturnType<typeof toLightweightEventRequest>`). Because the server payload
+ * and the client type are both derived from this one function, they cannot
+ * drift — which is what caused "Cause B": a field a card read but the list
+ * didn't send rendered blank on the card even though it saved fine.
+ *
+ * To expose a new field to the cards: add it here, once. TypeScript will then
+ * flag any card that reads a field this projection does not include.
+ *
+ * Keep this a pure projection (field copies + the few documented computed
+ * fields). Anything heavier belongs in the full-record endpoint.
+ */
+export function toLightweightEventRequest(event: EventRequest) {
+  return {
+    // ========== IDENTITY ==========
+    id: event.id,
+
+    // ========== ORGANIZATION (All cards) ==========
+    organizationName: event.organizationName,
+    organizationCategory: event.organizationCategory,
+    department: event.department,
+    partnerOrganizations: event.partnerOrganizations,
+
+    // ========== CONTACT (All cards, IntakeCallDialog) ==========
+    firstName: event.firstName,
+    lastName: event.lastName,
+    email: event.email,
+    phone: event.phone,
+    backupContactFirstName: (event as any).backupContactFirstName,
+    backupContactLastName: (event as any).backupContactLastName,
+    backupContactEmail: (event as any).backupContactEmail,
+    backupContactPhone: (event as any).backupContactPhone,
+    backupContactRole: (event as any).backupContactRole,
+
+    // ========== DATES (All cards) ==========
+    desiredEventDate: event.desiredEventDate,
+    scheduledEventDate: event.scheduledEventDate,
+    isConfirmed: event.isConfirmed,
+    backupDates: event.backupDates,
+
+    // ========== STATUS & WORKFLOW ==========
+    status: event.status,
+    statusChangedAt: event.statusChangedAt,
+    assignedTo: event.assignedTo,
+    nextAction: event.nextAction,
+    message: event.message,
+    scheduledCallDate: event.scheduledCallDate,
+
+    // ========== LOCATION (ScheduledCard, NewRequestCard) ==========
+    eventAddress: event.eventAddress,
+    latitude: event.latitude,
+    longitude: event.longitude,
+
+    // ========== SANDWICH COUNTS & TYPES ==========
+    estimatedSandwichCount: event.estimatedSandwichCount,
+    estimatedSandwichCountMin: event.estimatedSandwichCountMin,
+    estimatedSandwichCountMax: event.estimatedSandwichCountMax,
+    estimatedSandwichRangeType: event.estimatedSandwichRangeType,
+    actualSandwichCount: event.actualSandwichCount,
+    sandwichTypes: event.sandwichTypes,
+    hasRefrigeration: event.hasRefrigeration,
+    volunteerCount: event.volunteerCount,
+    actualAttendance: event.actualAttendance,
+    estimatedAttendance: event.estimatedAttendance,
+    attendanceAdults: event.attendanceAdults,
+    attendanceTeens: event.attendanceTeens,
+    attendanceKids: event.attendanceKids,
+
+    // ========== DRIVER STAFFING ==========
+    driversNeeded: event.driversNeeded,
+    assignedDriverIds: event.assignedDriverIds,
+    driverDetails: event.driverDetails,
+    selfTransport: event.selfTransport,
+    tentativeDriverIds: event.tentativeDriverIds,
+
+    // ========== SPEAKER STAFFING ==========
+    speakersNeeded: event.speakersNeeded,
+    assignedSpeakerIds: event.assignedSpeakerIds,
+    tentativeSpeakerIds: event.tentativeSpeakerIds,
+    speakerDetails: event.speakerDetails,
+
+    // ========== VOLUNTEER STAFFING ==========
+    volunteersNeeded: event.volunteersNeeded,
+    assignedVolunteerIds: event.assignedVolunteerIds,
+    tentativeVolunteerIds: event.tentativeVolunteerIds,
+    volunteerDetails: event.volunteerDetails,
+
+    // ========== VAN DRIVER ==========
+    vanDriverNeeded: event.vanDriverNeeded,
+    assignedVanDriverId: event.assignedVanDriverId,
+    isDhlVan: event.isDhlVan,
+    customVanDriverName: event.customVanDriverName,
+
+    // ========== TSP CONTACT (All cards) ==========
+    tspContact: event.tspContact,
+    tspContactAssigned: event.tspContactAssigned,
+    customTspContact: event.customTspContact,
+    tspContactAssignedDate: event.tspContactAssignedDate,
+
+    // ========== TOOLKIT STATUS ==========
+    toolkitSent: event.toolkitSent,
+    toolkitStatus: event.toolkitStatus,
+
+    // ========== TIMES (ScheduledCard, EventEditDialog) ==========
+    eventStartTime: event.eventStartTime,
+    eventEndTime: event.eventEndTime,
+    pickupTime: event.pickupTime,
+    pickupDateTime: event.pickupDateTime,
+    pickupTimeWindow: event.pickupTimeWindow,
+
+    // ========== TRACKING FLAGS ==========
+    addedToOfficialSheet: event.addedToOfficialSheet,
+    addedToOfficialSheetAt: event.addedToOfficialSheetAt,
+    showOnVolunteerHub: (event as any).showOnVolunteerHub,
+    isUnresponsive: event.isUnresponsive,
+    contactAttempts: event.contactAttempts,
+    lastContactAttempt: event.lastContactAttempt,
+    hasHostedBefore: event.previouslyHosted === 'yes', // computed from previouslyHosted
+    previouslyHosted: event.previouslyHosted,
+
+    // ========== NOTES (ScheduledCard, ScheduledCardEnhanced) ==========
+    planningNotes: event.planningNotes,
+    schedulingNotes: event.schedulingNotes,
+    contactAttemptsLog: event.contactAttemptsLog,
+    unresponsiveNotes: event.unresponsiveNotes,
+    followUpNotes: event.followUpNotes,
+    distributionNotes: event.distributionNotes,
+    duplicateNotes: event.duplicateNotes,
+    socialMediaPostNotes: event.socialMediaPostNotes,
+    socialMediaPostRequested: event.socialMediaPostRequested,
+    socialMediaPostRequestedDate: event.socialMediaPostRequestedDate,
+    socialMediaPostCompleted: event.socialMediaPostCompleted,
+    socialMediaPostCompletedDate: event.socialMediaPostCompletedDate,
+    socialMediaPostLink: (event as any).socialMediaPostLink,
+
+    // ========== RECIPIENT ALLOCATION (ScheduledCard, SpreadsheetView) ==========
+    assignedRecipientIds: event.assignedRecipientIds,
+    recipientAllocations: event.recipientAllocations,
+
+    // ========== SPECIAL FLAGS ==========
+    isMlkDayEvent: event.isMlkDayEvent,
+    isCorporatePriority: event.isCorporatePriority,
+    externalId: event.externalId,
+    overnightHoldingLocation: event.overnightHoldingLocation,
+
+    // ========== POSTPONEMENT (PostponedCard) ==========
+    tentativeNewDate: event.tentativeNewDate,
+    postponementReason: event.postponementReason,
+
+    // ========== NON-EVENT (NonEventCard) ==========
+    // Added with the §B9 projection: these were read by NonEventCard but were
+    // missing from the old hand-maintained mapper, so the reason/notes rendered
+    // blank on Non-Event cards (a live "Cause B" instance).
+    nonEventReason: (event as any).nonEventReason,
+    nonEventNotes: (event as any).nonEventNotes,
+    nonEventBy: (event as any).nonEventBy,
+    nonEventAt: (event as any).nonEventAt,
+
+    // ========== TIMESTAMPS ==========
+    createdAt: event.createdAt,
+    updatedAt: event.updatedAt,
+  };
+}
+
+/**
+ * The exact shape returned by `GET /api/event-requests/list`. Derived from the
+ * projection above so it can never drift from what the server actually sends.
+ */
+export type LightweightEventRequest = ReturnType<typeof toLightweightEventRequest>;


### PR DESCRIPTION
First step of **§B9 (Cause B)** — "saved but the card doesn't show it."

## Why
The list endpoint (`GET /api/event-requests/list`) returned a **140-line, hand-maintained field allow-list**. When a card started reading a field that wasn't in that list, the field saved to the DB fine but rendered **blank** on the card. The contract was invisible and drifted over time.

## What this does
- **Single source of truth:** extracts the projection into one shared function, `toLightweightEventRequest` (`shared/event-list-projection.ts`). The server maps through it, so the list shape lives in one obvious place — adding a card field is now a one-line edit there.
- **Fixes a live Cause B bug:** `nonEventReason` / `nonEventNotes` / `nonEventBy` / `nonEventAt` were read by `NonEventCard` but missing from the old mapper, so the reason rendered blank on Non-Event cards. Now included.
- **Exports `LightweightEventRequest`** (`ReturnType<typeof toLightweightEventRequest>`) as the foundation for future compile-time enforcement.
- Replaces the misleading "you MUST add it here" contract comment with a pointer to the shared projection.

## Safety
- **Net −1 pre-existing TypeScript error** (verified: the legacy file had 98 errors at baseline, 97 with this change — it removed one, added none). The shared file type-checks clean.
- Behavior-preserving for every existing field (same values, same shape) plus the four newly-included Non-Event fields.

## Deliberately out of scope (documented)
Full **client-side TypeScript enforcement** (typing cards as `LightweightEventRequest` so drift becomes a compile error) is deferred. It's entangled with pre-existing **schema type debt** — the `EventRequest` type generated from Drizzle is missing several real columns (`socialMediaPostLink`, `backupContact*`, `showOnVolunteerHub`, `nonEvent*`), which the old code hid with `as any`. A clean enforced type needs the schema type fixed first; that's a worthwhile but separate, app-wide pass. Centralizing the projection here already makes drift far less likely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwCxdLZ58uWtVqNFjA8TUc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of list serialization with intentional additive fields; no auth or write-path changes, and behavior is largely equivalent aside from fixing missing payload fields.
> 
> **Overview**
> **§B9 (Cause B) part 1:** stops the lightweight list response from drifting away from what event cards expect.
> 
> The **~140-line inline mapper** on `GET /api/event-requests/list` is replaced by **`toLightweightEventRequest`** in `shared/event-list-projection.ts`. New list fields are added in one place; **`LightweightEventRequest`** is exported for future client typing (not wired yet).
> 
> **Bug fixes:** the projection now includes **`nonEventReason` / `nonEventNotes` / `nonEventBy` / `nonEventAt`** (Non-Event cards were blank) and **`vanNeededLikely`** (In Process / Scheduled / scheduling UI). Existing fields are otherwise preserved; backup contacts use typed `EventRequest` fields instead of scattered `as any` in the route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb393483c0c33bd9c3f31dc1afd1c82531b138fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->