### PR TITLE
Centralize transition reason rule + side-effect; enforce reasons server-side (B11)

### DIFF
--- a/client/src/components/event-requests/constants.ts
+++ b/client/src/components/event-requests/constants.ts
@@ -16,6 +16,8 @@ export {
   VALID_STATUS_TRANSITIONS,
   isValidTransition,
   getTransitionError,
+  requiresReason,
+  getReasonField,
 } from '@shared/event-status-workflow';
 export type { EventStatus } from '@shared/event-status-workflow';
 

--- a/client/src/components/event-requests/hooks/useEventAssignments.tsx
+++ b/client/src/components/event-requests/hooks/useEventAssignments.tsx
@@ -8,7 +8,7 @@ import type { EventRequest } from '@shared/schema';
 import { logger } from '@/lib/logger';
 import { PERMISSIONS } from '@shared/auth-utils';
 import { hasPermission } from '@shared/unified-auth-utils';
-import { isValidTransition, getTransitionError, STATUS_DEFINITIONS } from '../constants';
+import { isValidTransition, getTransitionError, requiresReason, STATUS_DEFINITIONS } from '../constants';
 import type { EventStatus } from '@shared/event-status-workflow';
 
 export const useEventAssignments = () => {
@@ -648,8 +648,10 @@ export const useEventAssignments = () => {
       return 'blocked';
     }
 
-    // For declined, cancelled, non_event, and rescheduled: signal to caller to open reason/date dialog
-    if (status === 'declined' || status === 'cancelled' || status === 'non_event' || status === 'rescheduled') {
+    // Signal to caller to open the reason/date dialog. Reason-required statuses
+    // come from the shared workflow (single source of truth, also enforced
+    // server-side); rescheduled is special — it needs a new date, not a reason.
+    if (requiresReason(targetStatus) || targetStatus === 'rescheduled') {
       return 'needs_reason';
     }
 
@@ -679,14 +681,10 @@ export const useEventAssignments = () => {
       if (!confirmed) return 'blocked';
     }
 
+    // The "scheduled → default to desired date" rule now lives in the shared
+    // workflow and is applied server-side (getScheduledDateDefault), so every
+    // scheduling path gets it consistently — no need to set it here.
     const data: any = { status, ...additionalData };
-
-    // When marking as scheduled, set scheduledEventDate to desiredEventDate if not already set
-    if (status === 'scheduled') {
-      if (request && !request.scheduledEventDate && request.desiredEventDate) {
-        data.scheduledEventDate = request.desiredEventDate;
-      }
-    }
 
     try {
       await updateEventRequestMutation.mutateAsync({

--- a/server/routes/event-requests-legacy.ts
+++ b/server/routes/event-requests-legacy.ts
@@ -15,7 +15,7 @@ import {
 import { PERMISSIONS } from '@shared/auth-utils';
 import { hasPermission } from '@shared/unified-auth-utils';
 import { parseDateOnly, getTodayString, toDateOnlyString } from '@shared/date-utils';
-import { isValidTransition, getTransitionError, type EventStatus } from '@shared/event-status-workflow';
+import { isValidTransition, getTransitionError, requiresReason, getReasonField, getScheduledDateDefault, type EventStatus } from '@shared/event-status-workflow';
 import { parseSandwichCountInput } from '@shared/sandwich-count-utils';
 import { toLightweightEventRequest } from '@shared/event-list-projection';
 import { requirePermission } from '../middleware/auth';
@@ -2633,7 +2633,42 @@ router.patch(
           });
         }
 
+        // Enforce that reason-required transitions actually record a reason.
+        // Single source of truth: requiresReason()/getReasonField() in the shared
+        // workflow. The reason may arrive in this request OR already exist on the
+        // record (e.g. the Undo action restoring a prior declined/cancelled state,
+        // or re-entering the status). An explicit empty value counts as clearing.
+        if (requiresReason(toStatus)) {
+          const reasonField = getReasonField(toStatus)!;
+          const incoming = (processedUpdates as any)[reasonField];
+          const existing = (originalEvent as any)[reasonField];
+          const hasIncoming = typeof incoming === 'string' && incoming.trim() !== '';
+          const hasExisting = typeof existing === 'string' && existing.trim() !== '';
+          const clearingReason = incoming !== undefined && !hasIncoming;
+          if (!(hasIncoming || (!clearingReason && hasExisting))) {
+            logger.warn(`[PATCH /:id] Missing required reason for event ${id}: ${fromStatus} → ${toStatus}`);
+            return res.status(400).json({
+              message: `A reason is required to mark this event as "${toStatus}".`,
+              error: 'MISSING_REASON',
+              requestedStatus: toStatus,
+              reasonField,
+            });
+          }
+        }
+
         processedUpdates.statusChangedAt = new Date();
+
+        // Pure transition side-effect from the shared workflow: when scheduling
+        // an event with no date yet, fall back to its desired date. Applied here
+        // so every scheduling path is consistent (the client no longer does it).
+        const scheduledDateDefault = getScheduledDateDefault(
+          toStatus,
+          processedUpdates.scheduledEventDate ?? originalEvent.scheduledEventDate,
+          originalEvent.desiredEventDate,
+        );
+        if (scheduledDateDefault !== undefined) {
+          processedUpdates.scheduledEventDate = scheduledDateDefault;
+        }
 
         // If status is changing to 'completed', auto-confirm the event
         if (processedUpdates.status === 'completed') {

--- a/server/routes/event-requests-legacy.ts
+++ b/server/routes/event-requests-legacy.ts
@@ -15,7 +15,7 @@ import {
 import { PERMISSIONS } from '@shared/auth-utils';
 import { hasPermission } from '@shared/unified-auth-utils';
 import { parseDateOnly, getTodayString, toDateOnlyString } from '@shared/date-utils';
-import { isValidTransition, getTransitionError, requiresReason, getReasonField, getScheduledDateDefault, type EventStatus } from '@shared/event-status-workflow';
+import { isValidTransition, getTransitionError, requiresReason, getReasonField, getReasonSatisfyingFields, getScheduledDateDefault, type EventStatus } from '@shared/event-status-workflow';
 import { parseSandwichCountInput } from '@shared/sandwich-count-utils';
 import { toLightweightEventRequest } from '@shared/event-list-projection';
 import { requirePermission } from '../middleware/auth';
@@ -2634,24 +2634,25 @@ router.patch(
         }
 
         // Enforce that reason-required transitions actually record a reason.
-        // Single source of truth: requiresReason()/getReasonField() in the shared
-        // workflow. The reason may arrive in this request OR already exist on the
-        // record (e.g. the Undo action restoring a prior declined/cancelled state,
-        // or re-entering the status). An explicit empty value counts as clearing.
+        // Single source of truth: the shared workflow lists every field that can
+        // satisfy the requirement — the structured reason column (filled by the
+        // card-action dialogs) OR the matching/general notes (the full-form
+        // scheduling path documents the reason there). The requirement is met if
+        // ANY of those is non-empty after this PATCH (incoming value if provided,
+        // otherwise what's already on the record).
         if (requiresReason(toStatus)) {
-          const reasonField = getReasonField(toStatus)!;
-          const incoming = (processedUpdates as any)[reasonField];
-          const existing = (originalEvent as any)[reasonField];
-          const hasIncoming = typeof incoming === 'string' && incoming.trim() !== '';
-          const hasExisting = typeof existing === 'string' && existing.trim() !== '';
-          const clearingReason = incoming !== undefined && !hasIncoming;
-          if (!(hasIncoming || (!clearingReason && hasExisting))) {
+          const satisfied = getReasonSatisfyingFields(toStatus).some((field) => {
+            const incoming = (processedUpdates as any)[field];
+            const effective = incoming !== undefined ? incoming : (originalEvent as any)[field];
+            return typeof effective === 'string' && effective.trim() !== '';
+          });
+          if (!satisfied) {
             logger.warn(`[PATCH /:id] Missing required reason for event ${id}: ${fromStatus} → ${toStatus}`);
             return res.status(400).json({
-              message: `A reason is required to mark this event as "${toStatus}".`,
+              message: `A reason or note is required to mark this event as "${toStatus}".`,
               error: 'MISSING_REASON',
               requestedStatus: toStatus,
-              reasonField,
+              reasonField: getReasonField(toStatus),
             });
           }
         }

--- a/server/routes/event-requests-legacy.ts
+++ b/server/routes/event-requests-legacy.ts
@@ -2662,12 +2662,22 @@ router.patch(
         // Pure transition side-effect from the shared workflow: when scheduling
         // an event with no date yet, fall back to its desired date. Applied here
         // so every scheduling path is consistent (the client no longer does it).
+        //
+        // Resolve effective values with `!== undefined` (not `??`) so an explicit
+        // null in this PATCH (intentionally clearing a date) is respected, and a
+        // desired date updated in the same request is preferred over the stored one.
+        const effectiveScheduledDate =
+          processedUpdates.scheduledEventDate !== undefined
+            ? processedUpdates.scheduledEventDate
+            : originalEvent.scheduledEventDate;
+        const effectiveDesiredDate =
+          processedUpdates.desiredEventDate !== undefined
+            ? processedUpdates.desiredEventDate
+            : originalEvent.desiredEventDate;
         const scheduledDateDefault = getScheduledDateDefault(
           toStatus,
-          processedUpdates.scheduledEventDate ?? originalEvent.scheduledEventDate,
-          // Prefer a desired date set in this same request over the stored one,
-          // so updating the desired date and scheduling in one PATCH uses the new date.
-          processedUpdates.desiredEventDate ?? originalEvent.desiredEventDate,
+          effectiveScheduledDate,
+          effectiveDesiredDate,
         );
         if (scheduledDateDefault !== undefined) {
           processedUpdates.scheduledEventDate = scheduledDateDefault;

--- a/server/routes/event-requests-legacy.ts
+++ b/server/routes/event-requests-legacy.ts
@@ -2664,7 +2664,9 @@ router.patch(
         const scheduledDateDefault = getScheduledDateDefault(
           toStatus,
           processedUpdates.scheduledEventDate ?? originalEvent.scheduledEventDate,
-          originalEvent.desiredEventDate,
+          // Prefer a desired date set in this same request over the stored one,
+          // so updating the desired date and scheduling in one PATCH uses the new date.
+          processedUpdates.desiredEventDate ?? originalEvent.desiredEventDate,
         );
         if (scheduledDateDefault !== undefined) {
           processedUpdates.scheduledEventDate = scheduledDateDefault;

--- a/shared/event-status-workflow.ts
+++ b/shared/event-status-workflow.ts
@@ -180,6 +180,27 @@ export function getReasonField(status: EventStatus): string | undefined {
 }
 
 /**
+ * Fields whose presence satisfies the reason requirement, in priority order.
+ *
+ * The structured reason column is preferred (the card-action reason dialogs fill
+ * it), but the matching notes column AND the general planning/scheduling notes
+ * are also accepted — the full-form scheduling path records the reason in those
+ * free-text notes rather than the structured column. Accepting notes is a
+ * deliberate product choice: it keeps that form working, with the tradeoff that
+ * the structured reason column may stay empty for form-driven transitions.
+ */
+export const STATUS_REASON_SATISFYING_FIELDS: Partial<Record<EventStatus, string[]>> = {
+  declined: ['declinedReason', 'declinedNotes', 'planningNotes', 'schedulingNotes'],
+  cancelled: ['cancelledReason', 'cancelledNotes', 'planningNotes', 'schedulingNotes'],
+  non_event: ['nonEventReason', 'nonEventNotes', 'planningNotes', 'schedulingNotes'],
+};
+
+/** Fields that can satisfy the reason requirement for `status` (any non-empty one). */
+export function getReasonSatisfyingFields(status: EventStatus): string[] {
+  return STATUS_REASON_SATISFYING_FIELDS[status] ?? [];
+}
+
+/**
  * Pure transition side-effect: when an event becomes Scheduled with no scheduled
  * date set yet, fall back to its desired date.
  *

--- a/shared/event-status-workflow.ts
+++ b/shared/event-status-workflow.ts
@@ -171,12 +171,14 @@ export const STATUS_REASON_FIELD: Partial<Record<EventStatus, string>> = {
 
 /** Whether moving an event to `status` requires a reason to be recorded. */
 export function requiresReason(status: EventStatus): boolean {
-  return status in STATUS_REASON_FIELD;
+  // Own-property check (not `in`) so prototype keys like "toString" never match,
+  // even if called with an untrusted string at runtime.
+  return Object.prototype.hasOwnProperty.call(STATUS_REASON_FIELD, status);
 }
 
 /** The field name that carries the required reason for `status`, if any. */
 export function getReasonField(status: EventStatus): string | undefined {
-  return STATUS_REASON_FIELD[status];
+  return requiresReason(status) ? STATUS_REASON_FIELD[status] : undefined;
 }
 
 /**
@@ -197,7 +199,10 @@ export const STATUS_REASON_SATISFYING_FIELDS: Partial<Record<EventStatus, string
 
 /** Fields that can satisfy the reason requirement for `status` (any non-empty one). */
 export function getReasonSatisfyingFields(status: EventStatus): string[] {
-  return STATUS_REASON_SATISFYING_FIELDS[status] ?? [];
+  // Own-property check guards against prototype keys returning a function.
+  return Object.prototype.hasOwnProperty.call(STATUS_REASON_SATISFYING_FIELDS, status)
+    ? STATUS_REASON_SATISFYING_FIELDS[status]!
+    : [];
 }
 
 /**

--- a/shared/event-status-workflow.ts
+++ b/shared/event-status-workflow.ts
@@ -149,3 +149,52 @@ export function getTransitionError(from: EventStatus, to: EventStatus): string {
 
   return `Cannot move from "${fromLabel}" to "${toLabel}". Valid next statuses are: ${allowedLabels.join(', ')}.`;
 }
+
+/**
+ * Statuses that require a reason, and the field that carries it.
+ *
+ * Single source of truth for the "needs a reason" rule — consumed by BOTH the
+ * client (to open the reason dialog) and the server (to enforce that a reason is
+ * actually recorded). Previously this list was hardcoded only on the client and
+ * the server enforced nothing, so a non-dialog path could record a declined /
+ * cancelled / non-event with no reason.
+ *
+ * NOTE: `rescheduled` is intentionally NOT here — it requires a new *date*
+ * (collected by RescheduleDialog), not a reason. `standby` / `stalled` have
+ * reason columns in the schema but reasons remain optional for them by design.
+ */
+export const STATUS_REASON_FIELD: Partial<Record<EventStatus, string>> = {
+  declined: 'declinedReason',
+  cancelled: 'cancelledReason',
+  non_event: 'nonEventReason',
+};
+
+/** Whether moving an event to `status` requires a reason to be recorded. */
+export function requiresReason(status: EventStatus): boolean {
+  return status in STATUS_REASON_FIELD;
+}
+
+/** The field name that carries the required reason for `status`, if any. */
+export function getReasonField(status: EventStatus): string | undefined {
+  return STATUS_REASON_FIELD[status];
+}
+
+/**
+ * Pure transition side-effect: when an event becomes Scheduled with no scheduled
+ * date set yet, fall back to its desired date.
+ *
+ * Centralized here so EVERY scheduling path obeys the same rule. Previously this
+ * lived only in the client status handler, so other paths (e.g. QuickSchedule)
+ * could schedule an event without carrying a date forward. Returns the date to
+ * use, or undefined when no default applies. Impure side-effects (timestamps,
+ * acting user, auto-confirm) stay in the server handler.
+ */
+export function getScheduledDateDefault<T extends string | Date>(
+  toStatus: EventStatus,
+  currentScheduledDate: T | null | undefined,
+  desiredDate: T | null | undefined,
+): T | undefined {
+  if (toStatus !== 'scheduled') return undefined;
+  if (currentScheduledDate) return undefined;
+  return desiredDate ?? undefined;
+}

--- a/tests/unit/event-status-workflow-reason.test.ts
+++ b/tests/unit/event-status-workflow-reason.test.ts
@@ -38,6 +38,14 @@ describe('requiresReason / getReasonField', () => {
       expect(getReasonField(status as any)).toBe((STATUS_REASON_FIELD as any)[status]);
     }
   });
+
+  it('does not treat prototype keys as reason-required (own-property check)', () => {
+    for (const key of ['toString', 'constructor', 'hasOwnProperty', '__proto__']) {
+      expect(requiresReason(key as any)).toBe(false);
+      expect(getReasonField(key as any)).toBeUndefined();
+      expect(getReasonSatisfyingFields(key as any)).toEqual([]);
+    }
+  });
 });
 
 describe('getReasonSatisfyingFields', () => {

--- a/tests/unit/event-status-workflow-reason.test.ts
+++ b/tests/unit/event-status-workflow-reason.test.ts
@@ -1,6 +1,7 @@
 import {
   requiresReason,
   getReasonField,
+  getReasonSatisfyingFields,
   getScheduledDateDefault,
   STATUS_REASON_FIELD,
 } from '@shared/event-status-workflow';
@@ -36,6 +37,31 @@ describe('requiresReason / getReasonField', () => {
       expect(requiresReason(status as any)).toBe(true);
       expect(getReasonField(status as any)).toBe((STATUS_REASON_FIELD as any)[status]);
     }
+  });
+});
+
+describe('getReasonSatisfyingFields', () => {
+  it('accepts the structured reason, the matching notes, and general notes', () => {
+    // The full-form scheduling path records the reason in planning/scheduling
+    // notes rather than the structured column, so those must satisfy the guard.
+    expect(getReasonSatisfyingFields('declined')).toEqual(
+      expect.arrayContaining(['declinedReason', 'declinedNotes', 'planningNotes', 'schedulingNotes']),
+    );
+    expect(getReasonSatisfyingFields('cancelled')).toEqual(
+      expect.arrayContaining(['cancelledReason', 'cancelledNotes', 'planningNotes', 'schedulingNotes']),
+    );
+    expect(getReasonSatisfyingFields('non_event')).toEqual(
+      expect.arrayContaining(['nonEventReason', 'nonEventNotes', 'planningNotes', 'schedulingNotes']),
+    );
+  });
+
+  it('prefers the structured reason column first', () => {
+    expect(getReasonSatisfyingFields('declined')[0]).toBe('declinedReason');
+  });
+
+  it('returns nothing for statuses that do not require a reason', () => {
+    expect(getReasonSatisfyingFields('scheduled')).toEqual([]);
+    expect(getReasonSatisfyingFields('standby')).toEqual([]);
   });
 });
 

--- a/tests/unit/event-status-workflow-reason.test.ts
+++ b/tests/unit/event-status-workflow-reason.test.ts
@@ -1,0 +1,62 @@
+import {
+  requiresReason,
+  getReasonField,
+  getScheduledDateDefault,
+  STATUS_REASON_FIELD,
+} from '@shared/event-status-workflow';
+
+// These helpers are the single source of truth for "which transitions need a
+// reason" and the pure "scheduled -> default to desired date" side-effect.
+// Both the client status handler and the server PATCH handler consume them, so
+// the rules can't drift between layers.
+
+describe('requiresReason / getReasonField', () => {
+  it('requires a reason for declined, cancelled, and non_event', () => {
+    expect(requiresReason('declined')).toBe(true);
+    expect(requiresReason('cancelled')).toBe(true);
+    expect(requiresReason('non_event')).toBe(true);
+  });
+
+  it('does NOT require a reason for other statuses', () => {
+    // rescheduled needs a date (not a reason); standby/stalled are optional by design
+    for (const s of ['new', 'in_process', 'scheduled', 'rescheduled', 'completed', 'standby', 'stalled'] as const) {
+      expect(requiresReason(s)).toBe(false);
+    }
+  });
+
+  it('maps each reason-required status to its reason column', () => {
+    expect(getReasonField('declined')).toBe('declinedReason');
+    expect(getReasonField('cancelled')).toBe('cancelledReason');
+    expect(getReasonField('non_event')).toBe('nonEventReason');
+    expect(getReasonField('scheduled')).toBeUndefined();
+  });
+
+  it('keeps STATUS_REASON_FIELD and the helpers in sync', () => {
+    for (const status of Object.keys(STATUS_REASON_FIELD)) {
+      expect(requiresReason(status as any)).toBe(true);
+      expect(getReasonField(status as any)).toBe((STATUS_REASON_FIELD as any)[status]);
+    }
+  });
+});
+
+describe('getScheduledDateDefault', () => {
+  it('defaults to the desired date when scheduling with no scheduled date', () => {
+    expect(getScheduledDateDefault('scheduled', null, '2026-07-01')).toBe('2026-07-01');
+    expect(getScheduledDateDefault('scheduled', undefined, '2026-07-01')).toBe('2026-07-01');
+  });
+
+  it('does not override an existing scheduled date', () => {
+    expect(getScheduledDateDefault('scheduled', '2026-06-15', '2026-07-01')).toBeUndefined();
+  });
+
+  it('returns undefined when there is no desired date to fall back to', () => {
+    expect(getScheduledDateDefault('scheduled', null, null)).toBeUndefined();
+    expect(getScheduledDateDefault('scheduled', null, undefined)).toBeUndefined();
+  });
+
+  it('only applies to the scheduled status', () => {
+    expect(getScheduledDateDefault('completed', null, '2026-07-01')).toBeUndefined();
+    expect(getScheduledDateDefault('standby', null, '2026-07-01')).toBeUndefined();
+    expect(getScheduledDateDefault('rescheduled', null, '2026-07-01')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Part of **B11 (status-path consolidation)**. Status-transition *validity* was already a shared single source of truth (`event-status-workflow.ts`, used by client + server). This PR moves the two pieces of transition behavior that **weren't** shared — the "needs a reason" rule and one side-effect — into that same file, and makes the **server enforce** the reason rule.

## Why
- The "which transitions require a reason" rule was **hardcoded only on the client**; the server enforced nothing, so any non-dialog path could record a declined/cancelled/non-event with **no reason**.
- The "scheduled → default to the desired date" side-effect lived **only on the client status handler**, so other scheduling paths (e.g. QuickSchedule) didn't carry a date forward.

## What changed
**`shared/event-status-workflow.ts`** (the single source of truth):
- `STATUS_REASON_FIELD` + `requiresReason()` / `getReasonField()` — declined/cancelled/non_event require a reason and map to their column. `rescheduled` needs a *date* (not a reason); `standby`/`stalled` stay optional by design.
- `getScheduledDateDefault()` — the pure "scheduled → desired date" rule (generic so it preserves `Date` vs `string`).

**Client** (`useEventAssignments` + `constants` re-export):
- `needs_reason` is now derived from `requiresReason()` instead of a hardcoded list (can't drift from the server).
- Removed the client-side scheduled-date default — the server owns it now, so every path is consistent.

**Server** (`event-requests-legacy.ts` PATCH):
- **Reason enforcement**: moving to declined/cancelled/non_event with no reason **in the body AND none already on the record** → `400 MISSING_REASON`. The "already on record" escape is what keeps the **Undo** action and re-transitions from being wrongly rejected.
- Applies `getScheduledDateDefault()` in the transition block.

## Safety
- **No net-new TypeScript errors** (project total unchanged at 1498).
- New shared-helper unit tests: **8 passing**. Existing `mark-scheduled-save` regression suite: **9 passing**.
- Behavior-preserving for the normal flow — the reason dialogs already send the reasons, so only reason-less bypass paths are now rejected (the intended hardening).

## Scope notes
- Standby/stalled remain optional (per decision) — they have reason columns but no enforced collection.
- This complements retiring **QuickScheduleButton** (A3); together they remove the validation-bypass paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwCxdLZ58uWtVqNFjA8TUc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core event status PATCH behavior (new validation and date defaulting); normal UI flows should still pass, but API bypass paths will now fail as intended.
> 
> **Overview**
> Moves **reason-required** transitions and the **scheduled → desired date** default into `shared/event-status-workflow.ts` so client and server share one definition instead of duplicating logic.
> 
> The client now opens reason dialogs via `requiresReason()` (not a hardcoded status list) and no longer sets `scheduledEventDate` when marking scheduled—that default is applied on the server with `getScheduledDateDefault()`.
> 
> **Server PATCH** rejects transitions to `declined`, `cancelled`, or `non_event` when no structured reason or acceptable notes are present in the body or already on the record (`400 MISSING_REASON`). Unit tests cover the new helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19a891d4ca5b93a72ac46d9c004373d28a832b8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->