### PR TITLE
Hide QuickScheduleButton behind a default-off feature flag (A3)

### DIFF
--- a/client/src/components/event-requests/cards/InProcessCard.tsx
+++ b/client/src/components/event-requests/cards/InProcessCard.tsx
@@ -79,6 +79,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { QuickScheduleButton } from '@/components/event-requests/QuickScheduleButton';
+import { EVENT_REQUEST_FEATURES } from '@/components/event-requests/feature-flags';
 import { useReturningOrganization } from '@/hooks/use-returning-organization';
 import { RefreshCw } from 'lucide-react';
 import { useEventRequestContext } from '../context/EventRequestContext';
@@ -1752,24 +1753,27 @@ export const InProcessCard: React.FC<InProcessCardProps> = ({
               </TooltipContent>
             </Tooltip>
 
-            {/* Backup quick schedule button - bypasses form if main button has issues */}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div>
-                  <QuickScheduleButton
-                    eventId={request.id}
-                    eventName={request.organizationName || 'Event'}
-                    currentStatus={request.status}
-                    scheduledDate={request.desiredEventDate}
-                    size="sm"
-                    variant="outline"
-                  />
-                </div>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Quick schedule (bypass form)</p>
-              </TooltipContent>
-            </Tooltip>
+            {/* Legacy quick-schedule workaround — hidden behind a default-off flag
+                now that the full scheduling form is trusted. See feature-flags.ts. */}
+            {EVENT_REQUEST_FEATURES.quickScheduleButton && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div>
+                    <QuickScheduleButton
+                      eventId={request.id}
+                      eventName={request.organizationName || 'Event'}
+                      currentStatus={request.status}
+                      scheduledDate={request.desiredEventDate}
+                      size="sm"
+                      variant="outline"
+                    />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Quick schedule (bypass form)</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
 
             <Tooltip>
               <TooltipTrigger asChild>

--- a/client/src/components/event-requests/feature-flags.ts
+++ b/client/src/components/event-requests/feature-flags.ts
@@ -1,0 +1,16 @@
+/**
+ * Feature flags for the event-requests feature. Default OFF.
+ *
+ * These gate legacy / in-transition UI so it can be hidden without deleting the
+ * code yet. Flip a flag to true to re-enable locally if needed.
+ */
+export const EVENT_REQUEST_FEATURES = {
+  /**
+   * QuickScheduleButton: an emergency workaround that bypasses the full
+   * scheduling form and PATCHes status directly to 'scheduled'. Now that the
+   * full-form save path is trusted (and status changes are validated/centralized
+   * server-side), it's hidden by default. Kept in the tree for one cycle so it
+   * can be re-enabled quickly if anyone relied on it; remove once confirmed.
+   */
+  quickScheduleButton: false,
+} as const;

--- a/client/src/components/event-requests/feature-flags.ts
+++ b/client/src/components/event-requests/feature-flags.ts
@@ -1,8 +1,11 @@
 /**
- * Feature flags for the event-requests feature. Default OFF.
+ * Build-time UI toggles for the event-requests feature. Default OFF.
  *
- * These gate legacy / in-transition UI so it can be hidden without deleting the
- * code yet. Flip a flag to true to re-enable locally if needed.
+ * IMPORTANT: these are plain compile-time constants — NOT the runtime
+ * feature-flag system (`/api/feature-flags` + `useFeatureFlag`). There is no
+ * admin/runtime control: flipping one requires a code change and a rebuild/
+ * deploy. They exist only to gate legacy / in-transition UI so it can be hidden
+ * without deleting the code yet.
  */
 export const EVENT_REQUEST_FEATURES = {
   /**


### PR DESCRIPTION
Implements **A3** — retire the QuickScheduleButton bypass.

`QuickScheduleButton` is a legacy "emergency workaround" that bypasses the full scheduling form and PATCHes status directly to `'scheduled'`. Now that the full-form save path is trusted and status changes are validated + centralized server-side, it's no longer needed as a user-facing path.

## What changed
- New `client/src/components/event-requests/feature-flags.ts` with `EVENT_REQUEST_FEATURES`, **default off**.
- Gated the `QuickScheduleButton` render — its **only** call site (`InProcessCard.tsx`) — behind `EVENT_REQUEST_FEATURES.quickScheduleButton`.

"Hide first, delete later": the component is kept in the tree for one cycle so it can be re-enabled instantly (flip the flag) if anyone relied on it, then removed once confirmed.

## Safety
- **No net-new TypeScript errors** (project total unchanged at 1498).
- Pure subtraction of a UI path; nothing else references the component.

## Context
Complements **#421** (server-side status reason enforcement) — together they remove the last status-change paths that bypassed validation/centralization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwCxdLZ58uWtVqNFjA8TUc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes a single optional UI shortcut with no API or server changes; scheduling still goes through the main form and validated paths.
> 
> **Overview**
> **Hides the legacy `QuickScheduleButton`** on in-process event cards so staff can no longer bypass the full scheduling form and PATCH status straight to `scheduled`.
> 
> Adds **`EVENT_REQUEST_FEATURES`** in `feature-flags.ts` — **compile-time** toggles (not `/api/feature-flags`), with **`quickScheduleButton: false`** by default. **`InProcessCard`** is the only render site; the button and tooltip are shown only when that flag is true.
> 
> **Hide first, delete later:** the component stays in the repo so a one-line flag flip can restore it for a release cycle before removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5feb010e3b2f29e5e3d40165fbcf00fa65c333c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->