### PR TITLE
Finish dialog-context strangler: consumers use useEventDialogState() directly (A1)

### DIFF
--- a/client/src/components/event-requests/context/EventRequestContext.tsx
+++ b/client/src/components/event-requests/context/EventRequestContext.tsx
@@ -42,163 +42,10 @@ interface EventRequestContextType {
   itemsPerPage: number;
   setItemsPerPage: (items: number) => void;
 
-  // Selected event and editing
-  selectedEventRequest: EventRequest | null;
-  setSelectedEventRequest: (event: EventRequest | null) => void;
-  isEditing: boolean;
-  setIsEditing: (editing: boolean) => void;
-
-  // Dialog visibility states
-  showEventDetails: boolean;
-  setShowEventDetails: (show: boolean) => void;
-  showEventDetailsPreview: boolean;
-  setShowEventDetailsPreview: (show: boolean) => void;
-  showSchedulingDialog: boolean;
-  setShowSchedulingDialog: (show: boolean) => void;
-  showToolkitSentDialog: boolean;
-  setShowToolkitSentDialog: (show: boolean) => void;
-  showScheduleCallDialog: boolean;
-  setShowScheduleCallDialog: (show: boolean) => void;
-  showOneDayFollowUpDialog: boolean;
-  setShowOneDayFollowUpDialog: (show: boolean) => void;
-  showOneMonthFollowUpDialog: boolean;
-  setShowOneMonthFollowUpDialog: (show: boolean) => void;
-  showContactOrganizerDialog: boolean;
-  setShowContactOrganizerDialog: (show: boolean) => void;
-  showCollectionLog: boolean;
-  setShowCollectionLog: (show: boolean) => void;
-  showAssignmentDialog: boolean;
-  setShowAssignmentDialog: (show: boolean) => void;
-  showTspContactAssignmentDialog: boolean;
-  setShowTspContactAssignmentDialog: (show: boolean) => void;
-  showSandwichPlanningModal: boolean;
-  setShowSandwichPlanningModal: (show: boolean) => void;
-  showStaffingPlanningModal: boolean;
-  setShowStaffingPlanningModal: (show: boolean) => void;
-  showLogContactDialog: boolean;
-  setShowLogContactDialog: (show: boolean) => void;
-  showEditContactDialog: boolean;
-  setShowEditContactDialog: (show: boolean) => void;
-  showAiDateSuggestionDialog: boolean;
-  setShowAiDateSuggestionDialog: (show: boolean) => void;
-  showAiIntakeAssistantDialog: boolean;
-  setShowAiIntakeAssistantDialog: (show: boolean) => void;
-  showIntakeCallDialog: boolean;
-  setShowIntakeCallDialog: (show: boolean) => void;
-  showDeclineDialog: boolean;
-  setShowDeclineDialog: (show: boolean) => void;
-  showCancelDialog: boolean;
-  setShowCancelDialog: (show: boolean) => void;
-  showNonEventDialog: boolean;
-  setShowNonEventDialog: (show: boolean) => void;
-  showRescheduleDialog: boolean;
-  setShowRescheduleDialog: (show: boolean) => void;
-
-  // Event being acted upon
-  schedulingEventRequest: EventRequest | null;
-  setSchedulingEventRequest: (event: EventRequest | null) => void;
-  toolkitEventRequest: EventRequest | null;
-  setToolkitEventRequest: (event: EventRequest | null) => void;
-  collectionLogEventRequest: EventRequest | null;
-  setCollectionLogEventRequest: (event: EventRequest | null) => void;
-  contactEventRequest: EventRequest | null;
-  setContactEventRequest: (event: EventRequest | null) => void;
-  tspContactEventRequest: EventRequest | null;
-  setTspContactEventRequest: (event: EventRequest | null) => void;
-  logContactEventRequest: EventRequest | null;
-  setLogContactEventRequest: (event: EventRequest | null) => void;
-  editContactEventRequest: EventRequest | null;
-  setEditContactEventRequest: (event: EventRequest | null) => void;
-  editContactAttemptData: any | null;
-  setEditContactAttemptData: (data: any | null) => void;
-  aiSuggestionEventRequest: EventRequest | null;
-  setAiSuggestionEventRequest: (event: EventRequest | null) => void;
-  aiIntakeAssistantEventRequest: EventRequest | null;
-  setAiIntakeAssistantEventRequest: (event: EventRequest | null) => void;
-  intakeCallEventRequest: EventRequest | null;
-  setIntakeCallEventRequest: (event: EventRequest | null) => void;
-  reasonDialogEventRequest: EventRequest | null;
-  setReasonDialogEventRequest: (event: EventRequest | null) => void;
-  nonEventDialogEventRequest: EventRequest | null;
-  setNonEventDialogEventRequest: (event: EventRequest | null) => void;
-  rescheduleDialogEventRequest: EventRequest | null;
-  setRescheduleDialogEventRequest: (event: EventRequest | null) => void;
-  showNextActionDialog: boolean;
-  setShowNextActionDialog: (show: boolean) => void;
-  nextActionEventRequest: EventRequest | null;
-  setNextActionEventRequest: (event: EventRequest | null) => void;
-  nextActionMode: 'add' | 'edit' | 'complete';
-  setNextActionMode: (mode: 'add' | 'edit' | 'complete') => void;
-
-  // Assignment state
-  assignmentType: 'driver' | 'speaker' | 'volunteer' | null;
-  setAssignmentType: (type: 'driver' | 'speaker' | 'volunteer' | null) => void;
-  assignmentEventId: number | null;
-  setAssignmentEventId: (id: number | null) => void;
-  selectedAssignees: string[];
-  setSelectedAssignees: (assignees: string[]) => void;
-  isEditingAssignment: boolean;
-  setIsEditingAssignment: (editing: boolean) => void;
-  editingAssignmentPersonId: string | null;
-  setEditingAssignmentPersonId: (id: string | null) => void;
-  isVanDriverAssignment: boolean;
-  setIsVanDriverAssignment: (isVan: boolean) => void;
-
-  // Schedule call state
-  scheduleCallDate: string;
-  setScheduleCallDate: (date: string) => void;
-  scheduleCallTime: string;
-  setScheduleCallTime: (time: string) => void;
-
-  // Follow-up notes
-  followUpNotes: string;
-  setFollowUpNotes: (notes: string) => void;
-
-  // Inline editing state for scheduled events
-  editingScheduledId: number | null;
-  setEditingScheduledId: (id: number | null) => void;
-  editingField: string | null;
-  setEditingField: (field: string | null) => void;
-  editingValue: string;
-  setEditingValue: (value: string) => void;
-
-  // Inline sandwich editing states
-  inlineSandwichMode: 'total' | 'types' | 'range';
-  setInlineSandwichMode: (mode: 'total' | 'types' | 'range') => void;
-  inlineTotalCount: number;
-  setInlineTotalCount: (count: number) => void;
-  inlineSandwichTypes: Array<{type: string, quantity: number}>;
-  setInlineSandwichTypes: (types: Array<{type: string, quantity: number}>) => void;
-  inlineRangeMin: number;
-  setInlineRangeMin: (value: number) => void;
-  inlineRangeMax: number;
-  setInlineRangeMax: (value: number) => void;
-  inlineRangeType: string;
-  setInlineRangeType: (value: string) => void;
-
-  // Modal sandwich editing states
-  modalSandwichMode: 'total' | 'types';
-  setModalSandwichMode: (mode: 'total' | 'types') => void;
-  modalTotalCount: number;
-  setModalTotalCount: (count: number) => void;
-  modalSandwichTypes: Array<{type: string, quantity: number}>;
-  setModalSandwichTypes: (types: Array<{type: string, quantity: number}>) => void;
-
-  // Completed event inline editing
-  editingCompletedId: number | null;
-  setEditingCompletedId: (id: number | null) => void;
-  completedEdit: any;
-  setCompletedEdit: (edit: any) => void;
-
-  // Custom person data for assignment
-  customPersonData: {
-    firstName: string;
-    lastName: string;
-    email: string;
-    phone: string;
-    vanCapable: boolean;
-  };
-  setCustomPersonData: (data: any) => void;
+  // NOTE: dialog / inline-editing / assignment / sandwich-edit state lives
+  // ONLY on EventDialogContext now. Consume it via useEventDialogState().
+  // The Strangler pass-through that re-exported those fields here was removed
+  // so consumers subscribe to just the context they need (fewer re-renders).
 
   // Computed data
   requestsByStatus: Record<string, EventRequest[]>;
@@ -686,11 +533,6 @@ const EventRequestProviderInner: React.FC<EventRequestProviderProps> = ({
     itemsPerPage,
     setItemsPerPage,
 
-    // ---- Pass-through from EventDialogContext ----
-    // Spread last so the field shape matches what consumers expect today.
-    // Strip the helper-only `openEventDetails` field — it's part of the
-    // EventDialogContext API, not the back-compat surface.
-    ...(({ openEventDetails: _omit, ...rest }) => rest)(dialog),
   }), [
     // Query results / data this context owns
     eventRequests, isLoading, isPlaceholderData, statusCountsLoading,
@@ -700,10 +542,6 @@ const EventRequestProviderInner: React.FC<EventRequestProviderProps> = ({
     statusFilter, myAssignmentsStatusFilter, confirmationFilter, sortBy,
     // Pagination
     currentPage, itemsPerPage,
-    // Pass-through. We only need to depend on the dialog object identity
-    // because EventDialogProvider already memoizes its own value with the
-    // full sub-deps; if any dialog field changes, `dialog` is a new object.
-    dialog,
   ]);
 
   return (

--- a/client/src/components/event-requests/context/EventRequestContext.tsx
+++ b/client/src/components/event-requests/context/EventRequestContext.tsx
@@ -83,9 +83,10 @@ interface EventRequestProviderProps {
 }
 
 /**
- * Public provider. Wraps the inner provider in EventDialogProvider so the
- * inner can `useEventDialogState()` and pass dialog fields through on the
- * existing EventRequestContext value (Strangler Pattern, PR 1 of 3).
+ * Public provider. Wraps the tree in EventDialogProvider so components can call
+ * useEventDialogState() for dialog/inline-edit state, while this provider serves
+ * data/view/pagination via useEventRequestContext(). (The two were previously
+ * merged; the dialog state was split out and the pass-through removed.)
  */
 export const EventRequestProvider: React.FC<EventRequestProviderProps> = (props) => (
   <EventDialogProvider>
@@ -491,11 +492,11 @@ const EventRequestProviderInner: React.FC<EventRequestProviderProps> = ({
     }
   }, [initialTab, initialEventId, eventRequests, hasHandledInitialEvent]);
 
-  // Memoize context value. Dialog/inline-editing fields come from the
-  // separate EventDialogContext via `dialog` and are spread here so existing
-  // consumers see the same shape (Strangler Pattern pass-through). PR 2 will
-  // switch consumers to call useEventDialogState() directly and remove the
-  // dialog spread, which is where the re-render perf win lands.
+  // Memoize context value. This context now owns ONLY data / view / pagination
+  // state — dialog and inline-editing state lives on EventDialogContext and is
+  // consumed directly via useEventDialogState(). The Strangler pass-through that
+  // used to spread those fields here was removed (that's where the re-render win
+  // landed: consumers subscribe to just the context they need).
   const value: EventRequestContextType = useMemo(() => ({
     // ---- Fields owned by this context ----
     // Data

--- a/client/src/components/event-requests/dialogs/AssignmentDialog.tsx
+++ b/client/src/components/event-requests/dialogs/AssignmentDialog.tsx
@@ -31,6 +31,7 @@ import {
   CircleHelp,
 } from 'lucide-react';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import type { AvailabilitySlot } from '@shared/schema';
 import { logger } from '@/lib/logger';
 
@@ -462,7 +463,8 @@ export const AssignmentDialog: React.FC<AssignmentDialogProps> = ({
   const [isTentative, setIsTentative] = useState(false);
 
   // Get context to find the event date
-  const { assignmentEventId, eventRequests } = useEventRequestContext();
+  const { eventRequests } = useEventRequestContext();
+  const { assignmentEventId } = useEventDialogState();
 
   // Find the current event request
   const currentEvent = useMemo(() => {

--- a/client/src/components/event-requests/hooks/useEventAssignments.tsx
+++ b/client/src/components/event-requests/hooks/useEventAssignments.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import { useEventMutations } from './useEventMutations';
 import { useEventQueries } from './useEventQueries';
 import type { EventRequest } from '@shared/schema';
@@ -21,6 +22,8 @@ export const useEventAssignments = () => {
   const { updateEventRequestMutation, assignRecipientsMutation } = useEventMutations();
   const {
     eventRequests,
+  } = useEventRequestContext();
+  const {
     setShowAssignmentDialog,
     setAssignmentType,
     setAssignmentEventId,
@@ -28,7 +31,7 @@ export const useEventAssignments = () => {
     setEditingAssignmentPersonId,
     setSelectedAssignees,
     setIsVanDriverAssignment,
-  } = useEventRequestContext();
+  } = useEventDialogState();
 
   // Helper function to safely parse PostgreSQL arrays
   const parsePostgresArray = (assignments: any): string[] => {

--- a/client/src/components/event-requests/hooks/useEventMutations.tsx
+++ b/client/src/components/event-requests/hooks/useEventMutations.tsx
@@ -3,6 +3,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useErrorToast } from '@/hooks/use-error-toast';
 import { apiRequest, invalidateEventRequestQueries, applyEventRequestSaveToCache, applyPatchResponseToCache, patchEventInListCaches, refreshEventRequestListAndCounts } from '@/lib/queryClient';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import { logger } from '@/lib/logger';
 
 export const useEventMutations = () => {
@@ -25,7 +26,7 @@ export const useEventMutations = () => {
     setEditingScheduledId,
     setEditingField,
     setEditingValue,
-  } = useEventRequestContext();
+  } = useEventDialogState();
 
   const eventReportContext = () =>
     selectedEventRequest?.id

--- a/client/src/components/event-requests/index.tsx
+++ b/client/src/components/event-requests/index.tsx
@@ -6,6 +6,7 @@ import {
   EventRequestProvider,
   useEventRequestContext,
 } from './context/EventRequestContext';
+import { useEventDialogState } from './context/EventDialogContext';
 import { NewRequestsTab } from './tabs/NewRequestsTab';
 import { InProcessTab } from './tabs/InProcessTab';
 import { ScheduledTab } from './tabs/ScheduledTab';
@@ -143,7 +144,9 @@ const EventRequestsManagementContent: React.FC = () => {
     statusCountsLoading,
     quickFilter,
     setQuickFilter,
+  } = useEventRequestContext();
 
+  const {
     // Dialog states
     showEventDetails,
     setShowEventDetails,
@@ -247,7 +250,7 @@ const EventRequestsManagementContent: React.FC = () => {
     setScheduleCallTime,
     followUpNotes,
     setFollowUpNotes,
-  } = useEventRequestContext();
+  } = useEventDialogState();
 
   // Fetch ALL active events (scheduled + in_process + rescheduled) for dashboard cards
   // This query is independent of the active tab, ensuring driver counts are always accurate

--- a/client/src/components/event-requests/tabs/AdminOverviewTab.tsx
+++ b/client/src/components/event-requests/tabs/AdminOverviewTab.tsx
@@ -7,6 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 import { formatDateShort } from '@/lib/date-utils';
 import { LastContactAgeBadge } from '@/components/event-requests/LastContactAgeBadge';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import { ActivityFeed } from '@/components/activity-feed';
 
 interface TspContactStats {
@@ -28,7 +29,8 @@ interface AdminOverviewTabProps {
 }
 
 export function AdminOverviewTab({ eventRequests }: AdminOverviewTabProps) {
-  const { setSelectedEventRequest, setShowEventDetails, setActiveTab } = useEventRequestContext();
+  const { setActiveTab } = useEventRequestContext();
+  const { setSelectedEventRequest, setShowEventDetails } = useEventDialogState();
   const [sortBy, setSortBy] = useState<'name' | 'total' | 'new' | 'in_process'>('total');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
   const [statusFilter, setStatusFilter] = useState<'all' | 'new' | 'in_process' | 'scheduled'>('all');

--- a/client/src/components/event-requests/tabs/AllEventsTab.tsx
+++ b/client/src/components/event-requests/tabs/AllEventsTab.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useEventFilters } from '../hooks/useEventFilters';
 import { useEventAssignments } from '../hooks/useEventAssignments';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -57,15 +58,17 @@ export const AllEventsTab: React.FC = () => {
   const { paginatedRequests } = useEventFilters();
   const { resolveUserName } = useEventAssignments();
   const {
-    setSelectedEventRequest,
-    setIsEditing,
-    setShowEventDetails,
     statusFilter,
     setStatusFilter,
     sortBy,
     setSortBy,
     setCurrentPage,
   } = useEventRequestContext();
+  const {
+    setSelectedEventRequest,
+    setIsEditing,
+    setShowEventDetails,
+  } = useEventDialogState();
 
   const openEvent = (request: EventRequest) => {
     setSelectedEventRequest(request);

--- a/client/src/components/event-requests/tabs/CompletedTab.tsx
+++ b/client/src/components/event-requests/tabs/CompletedTab.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import { useEventFilters } from '../hooks/useEventFilters';
 import { useEventMutations } from '../hooks/useEventMutations';
 import { useEventAssignments } from '../hooks/useEventAssignments';
@@ -32,6 +33,9 @@ export const CompletedTab: React.FC = () => {
 
   const {
     isLoading,
+  } = useEventRequestContext();
+
+  const {
     setSelectedEventRequest,
     setIsEditing,
     setShowEventDetails,
@@ -48,7 +52,7 @@ export const CompletedTab: React.FC = () => {
     setShowNextActionDialog,
     setNextActionEventRequest,
     setNextActionMode,
-  } = useEventRequestContext();
+  } = useEventDialogState();
 
   const completedRequests = filterRequestsByStatus('completed') || [];
 

--- a/client/src/components/event-requests/tabs/DeclinedTab.tsx
+++ b/client/src/components/event-requests/tabs/DeclinedTab.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import { useEventFilters } from '../hooks/useEventFilters';
 import { useEventMutations } from '../hooks/useEventMutations';
 import { useEventAssignments } from '../hooks/useEventAssignments';
@@ -21,6 +22,9 @@ export const DeclinedTab: React.FC = () => {
 
   const {
     isLoading,
+  } = useEventRequestContext();
+
+  const {
     setSelectedEventRequest,
     setIsEditing,
     setShowEventDetails,
@@ -28,7 +32,7 @@ export const DeclinedTab: React.FC = () => {
     setContactEventRequest,
     setShowLogContactDialog,
     setLogContactEventRequest,
-  } = useEventRequestContext();
+  } = useEventDialogState();
 
   const declinedRequests = filterRequestsByStatus('declined');
   const cancelledRequests = filterRequestsByStatus('cancelled');

--- a/client/src/components/event-requests/tabs/InProcessTab.tsx
+++ b/client/src/components/event-requests/tabs/InProcessTab.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import { useEventFilters } from '../hooks/useEventFilters';
 import { useEventMutations } from '../hooks/useEventMutations';
 import { useEventAssignments } from '../hooks/useEventAssignments';
@@ -33,6 +34,9 @@ export const InProcessTab: React.FC = () => {
 
   const {
     isLoading,
+  } = useEventRequestContext();
+
+  const {
     setSelectedEventRequest,
     setIsEditing,
     setShowEventDetails,
@@ -59,7 +63,7 @@ export const InProcessTab: React.FC = () => {
     setNextActionMode,
     setShowIntakeCallDialog,
     setIntakeCallEventRequest,
-  } = useEventRequestContext();
+  } = useEventDialogState();
 
   const inProcessRequests = filterRequestsByStatus('in_process');
 

--- a/client/src/components/event-requests/tabs/MyAssignmentsTab.tsx
+++ b/client/src/components/event-requests/tabs/MyAssignmentsTab.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import { useEventFilters } from '../hooks/useEventFilters';
 import { useEventMutations } from '../hooks/useEventMutations';
 import { useEventAssignments } from '../hooks/useEventAssignments';
@@ -45,6 +46,11 @@ export const MyAssignmentsTab: React.FC = () => {
 
   const {
     isLoading,
+    myAssignmentsStatusFilter,
+    setMyAssignmentsStatusFilter,
+  } = useEventRequestContext();
+
+  const {
     setSelectedEventRequest,
     setIsEditing,
     setShowEventDetails,
@@ -68,8 +74,6 @@ export const MyAssignmentsTab: React.FC = () => {
     setShowNextActionDialog,
     setNextActionEventRequest,
     setNextActionMode,
-    myAssignmentsStatusFilter,
-    setMyAssignmentsStatusFilter,
 
     // Inline editing states for scheduled events
     editingScheduledId,
@@ -102,7 +106,7 @@ export const MyAssignmentsTab: React.FC = () => {
     setReasonDialogEventRequest,
     setShowNonEventDialog,
     setNonEventDialogEventRequest,
-  } = useEventRequestContext();
+  } = useEventDialogState();
 
   // Helper functions for ScheduledCardEnhanced
   const quickToggleBoolean = (id: number, field: 'isConfirmed' | 'addedToOfficialSheet' | 'showOnVolunteerHub', currentValue: boolean) => {

--- a/client/src/components/event-requests/tabs/NewRequestsTab.tsx
+++ b/client/src/components/event-requests/tabs/NewRequestsTab.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import { useEventFilters } from '../hooks/useEventFilters';
 import { useEventMutations } from '../hooks/useEventMutations';
 import { useEventAssignments } from '../hooks/useEventAssignments';
@@ -29,6 +30,9 @@ export const NewRequestsTab: React.FC = () => {
 
   const {
     isLoading,
+  } = useEventRequestContext();
+
+  const {
     setSelectedEventRequest,
     setIsEditing,
     setShowEventDetails,
@@ -56,7 +60,7 @@ export const NewRequestsTab: React.FC = () => {
     setReasonDialogEventRequest,
     setShowNonEventDialog,
     setNonEventDialogEventRequest,
-  } = useEventRequestContext();
+  } = useEventDialogState();
 
   const newRequests = filterRequestsByStatus('new');
 

--- a/client/src/components/event-requests/tabs/NonEventTab.tsx
+++ b/client/src/components/event-requests/tabs/NonEventTab.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import { useEventFilters } from '../hooks/useEventFilters';
 import { useEventMutations } from '../hooks/useEventMutations';
 import { useEventAssignments } from '../hooks/useEventAssignments';
@@ -18,10 +19,13 @@ export const NonEventTab: React.FC = () => {
 
   const {
     isLoading,
+  } = useEventRequestContext();
+
+  const {
     setSelectedEventRequest,
     setIsEditing,
     setShowEventDetails,
-  } = useEventRequestContext();
+  } = useEventDialogState();
 
   const nonEventRequests = filterRequestsByStatus('non_event');
 

--- a/client/src/components/event-requests/tabs/RescheduledTab.tsx
+++ b/client/src/components/event-requests/tabs/RescheduledTab.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import { useEventFilters } from '../hooks/useEventFilters';
 import { useEventMutations } from '../hooks/useEventMutations';
 import { useEventAssignments } from '../hooks/useEventAssignments';
@@ -21,10 +22,13 @@ export const RescheduledTab: React.FC = () => {
 
   const {
     isLoading,
+  } = useEventRequestContext();
+
+  const {
     setSelectedEventRequest,
     setIsEditing,
     setShowEventDetails,
-  } = useEventRequestContext();
+  } = useEventDialogState();
 
   const rescheduledRequests = filterRequestsByStatus('rescheduled');
 

--- a/client/src/components/event-requests/tabs/ScheduledTab.tsx
+++ b/client/src/components/event-requests/tabs/ScheduledTab.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import { useEventFilters } from '../hooks/useEventFilters';
 import { useEventMutations } from '../hooks/useEventMutations';
 import { useEventAssignments } from '../hooks/useEventAssignments';
@@ -89,6 +90,9 @@ export const ScheduledTab: React.FC = () => {
   const {
     eventRequests,
     isLoading,
+  } = useEventRequestContext();
+
+  const {
     setSelectedEventRequest,
     setIsEditing,
     setShowEventDetails,
@@ -130,7 +134,7 @@ export const ScheduledTab: React.FC = () => {
     setInlineRangeMax,
     inlineRangeType,
     setInlineRangeType,
-  } = useEventRequestContext();
+  } = useEventDialogState();
 
   // Include both 'scheduled' and 'rescheduled' events on the Scheduled tab
   const scheduledOnly = filterRequestsByStatus('scheduled');

--- a/client/src/components/event-requests/tabs/StalledTab.tsx
+++ b/client/src/components/event-requests/tabs/StalledTab.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import { useEventFilters } from '../hooks/useEventFilters';
 import { useEventMutations } from '../hooks/useEventMutations';
 import { useEventAssignments } from '../hooks/useEventAssignments';
@@ -21,6 +22,9 @@ export const StalledTab: React.FC = () => {
 
   const {
     isLoading,
+  } = useEventRequestContext();
+
+  const {
     setSelectedEventRequest,
     setIsEditing,
     setShowEventDetails,
@@ -30,7 +34,7 @@ export const StalledTab: React.FC = () => {
     setLogContactEventRequest,
     setShowDeclineDialog,
     setReasonDialogEventRequest,
-  } = useEventRequestContext();
+  } = useEventDialogState();
 
   const stalledRequests = filterRequestsByStatus('stalled');
 

--- a/client/src/components/event-requests/tabs/StandbyTab.tsx
+++ b/client/src/components/event-requests/tabs/StandbyTab.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import { useEventFilters } from '../hooks/useEventFilters';
 import { useEventMutations } from '../hooks/useEventMutations';
 import { useEventAssignments } from '../hooks/useEventAssignments';
@@ -21,6 +22,9 @@ export const StandbyTab: React.FC = () => {
 
   const {
     isLoading,
+  } = useEventRequestContext();
+
+  const {
     setSelectedEventRequest,
     setIsEditing,
     setShowEventDetails,
@@ -28,7 +32,7 @@ export const StandbyTab: React.FC = () => {
     setContactEventRequest,
     setShowLogContactDialog,
     setLogContactEventRequest,
-  } = useEventRequestContext();
+  } = useEventDialogState();
 
   const standbyRequests = filterRequestsByStatus('standby');
 

--- a/client/src/components/event-requests/views/ScheduledSpreadsheetView.tsx
+++ b/client/src/components/event-requests/views/ScheduledSpreadsheetView.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useEventRequestContext } from '../context/EventRequestContext';
+import { useEventDialogState } from '../context/EventDialogContext';
 import { useEventMutations } from '../hooks/useEventMutations';
 import { useEventAssignments } from '../hooks/useEventAssignments';
 import { useAnalytics } from '@/hooks/useAnalytics';
@@ -383,6 +384,10 @@ const formatAddress = (input: string): string => {
 export const ScheduledSpreadsheetView: React.FC<ScheduledSpreadsheetViewProps> = ({ onEventDateClick, openAssignmentDialog }) => {
   const {
     eventRequests,
+    setActiveTab,
+  } = useEventRequestContext();
+
+  const {
     editingScheduledId,
     setEditingScheduledId,
     editingField,
@@ -390,8 +395,7 @@ export const ScheduledSpreadsheetView: React.FC<ScheduledSpreadsheetViewProps> =
     editingValue,
     setEditingValue,
     setSelectedEventRequest,
-    setActiveTab,
-  } = useEventRequestContext();
+  } = useEventDialogState();
 
   const { updateEventRequestMutation, updateScheduledFieldMutation } = useEventMutations();
   const { resolveUserName } = useEventAssignments();


### PR DESCRIPTION
Completes **A1**. Dialog/inline-editing state already lived in its own `EventDialogContext`, but `EventRequestContext` re-exported every field via a Strangler pass-through so consumers didn't have to change. This finishes the migration and removes the pass-through.

## What changed
- **`EventRequestContext`**: removed the ~150-line duplicated dialog-field block from its type and the `...dialog` value pass-through. It now owns only **data / view / pagination** state. (Still calls `useEventDialogState()` internally for the initial-event auto-open helper.)
- **17 consumers** (`index.tsx`, all tabs, `useEventMutations`, `useEventAssignments`, `ScheduledSpreadsheetView`, `AssignmentDialog`) now read dialog/inline-edit fields from **`useEventDialogState()`** directly; data/view/pagination stay on `useEventRequestContext()`.

## Why
This is where the **re-render win** the code comments promised actually lands: components subscribe to just the context they need, so opening/closing a dialog no longer re-renders list-only consumers (and vice versa). Behavior-preserving — same state, same provider, just a different hook.

## Why not a single `activeDialog` enum
The original A1 idea was one `activeDialog` enum. The audit found several dialogs **layer** over the Details dialog (e.g. Assignment/Scheduling opened on top of it), so a global enum forcing mutual exclusivity would regress that UX for little benefit. Context separation was the right, safe scope.

## Safety
- **`tsc` back to baseline (1498), zero net-new errors** (1812 with the pass-through removed → 1498 once all 314 consumer sites were migrated).
- **No suppressions** — grep over the diff for `as any` / `@ts-ignore` / `@ts-expect-error` returns none.
- `mark-scheduled-save` regression suite passes (9/9).
- `EventDialogContext` itself untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwCxdLZ58uWtVqNFjA8TUc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide refactor across the main event-requests UI; regressions would show up as broken dialog open/close or stale list state, but no server or auth changes.
> 
> **Overview**
> Completes the **Strangler** split between **`EventRequestContext`** (data, tabs, filters, pagination) and **`EventDialogContext`** (dialogs, selected event, assignments, inline edits).
> 
> **`EventRequestContext`** drops the large duplicated dialog-field surface from its type and stops spreading `EventDialogContext` into the provider value, so its memoized value no longer changes when a dialog opens or inline edit state updates.
> 
> **Consumers** (`index.tsx`, status tabs, `useEventMutations`, `useEventAssignments`, `AssignmentDialog`, `ScheduledSpreadsheetView`, etc.) now call **`useEventDialogState()`** for dialog and editing setters while keeping **`useEventRequestContext()`** for list/view state. Intended effect: fewer unnecessary re-renders across the event-requests tree with the same providers and behavior (including layered dialogs over details).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d0b7a4a6a0217287c27b4de2d628b227933c542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->