### PR TITLE
Harden partial-record hydration (retry on failure + always-fresh) — #426 follow-up

### DIFF
--- a/client/src/components/event-requests/EventSchedulingForm.tsx
+++ b/client/src/components/event-requests/EventSchedulingForm.tsx
@@ -281,7 +281,7 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
   // it everywhere below. A full-form save is blocked (in performSubmit) until the
   // full record loads, so a partial record can never blank the omitted columns.
   const recordIsPartial = !!rawEventRequest?.id && !isFullEventRecord(rawEventRequest);
-  const { data: hydratedEventRequest, isError: hydrationFailed, refetch: refetchHydration } = useQuery<EventRequest>({
+  const { data: hydratedEventRequest, isError: hydrationFailed, isFetching: hydrationFetching, refetch: refetchHydration } = useQuery<EventRequest>({
     queryKey: ['/api/event-requests', rawEventRequest?.id, 'full'],
     queryFn: () => apiRequest('GET', `/api/event-requests/${rawEventRequest!.id}`),
     enabled: dialogOpen && recordIsPartial,
@@ -904,16 +904,18 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
       return;
     }
 
-    // Block saving a partial record (e.g. opened from the map) until the full
-    // record has hydrated — a full-form save from a partial record would
-    // overwrite the columns the partial source omitted (notes, backup contacts,
-    // toolkit, follow-up) with blanks.
-    if (recordIsPartial && !hydratedEventRequest) {
+    // Block saving a partial record (e.g. opened from the map) until the FULL
+    // record is freshly hydrated. Also block while a hydration fetch is in flight
+    // or has errored: refetchOnMount serves the stale cached copy during the
+    // background refetch, and saving then would build the payload from stale
+    // values. A full-form save from a partial/stale record would overwrite the
+    // columns the partial source omitted (notes, backup contacts, toolkit, etc.).
+    if (recordIsPartial && (!hydratedEventRequest || hydrationFetching || hydrationFailed)) {
       setIsSubmitting(false);
-      if (hydrationFailed) {
-        // The full-record fetch failed (not just still loading). Don't leave the
-        // user stuck behind a "loading" message — retry and tell them plainly.
-        // Saving stays blocked so a partial payload can't overwrite real data.
+      if (hydrationFailed && !hydrationFetching) {
+        // The full-record fetch failed and isn't already retrying. Don't leave
+        // the user stuck behind a "loading" message — retry and tell them plainly.
+        // Saving stays blocked so a partial/stale payload can't overwrite data.
         logger.log('⛔ Save blocked: full event failed to load; retrying');
         refetchHydration();
         toast({
@@ -923,8 +925,8 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
           duration: Number.POSITIVE_INFINITY,
         });
       } else {
-        logger.log('⛔ Save blocked: full record not hydrated yet');
-        toast({ title: 'Loading full event…', description: 'Please wait a moment for the full event to load before saving.', variant: 'destructive' });
+        logger.log('⛔ Save blocked: full record not freshly hydrated yet');
+        toast({ title: 'Loading full event…', description: 'Please wait a moment for the full event to finish loading before saving.', variant: 'destructive' });
       }
       return;
     }

--- a/client/src/components/event-requests/EventSchedulingForm.tsx
+++ b/client/src/components/event-requests/EventSchedulingForm.tsx
@@ -281,10 +281,14 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
   // it everywhere below. A full-form save is blocked (in performSubmit) until the
   // full record loads, so a partial record can never blank the omitted columns.
   const recordIsPartial = !!rawEventRequest?.id && !isFullEventRecord(rawEventRequest);
-  const { data: hydratedEventRequest } = useQuery<EventRequest>({
+  const { data: hydratedEventRequest, isError: hydrationFailed, refetch: refetchHydration } = useQuery<EventRequest>({
     queryKey: ['/api/event-requests', rawEventRequest?.id, 'full'],
     queryFn: () => apiRequest('GET', `/api/event-requests/${rawEventRequest!.id}`),
     enabled: dialogOpen && recordIsPartial,
+    // Always refetch fresh on open: surgical saves no longer write this 'full'
+    // cache key, so a cached copy could be stale when reopening from the map.
+    staleTime: 0,
+    refetchOnMount: 'always',
   });
   const eventRequest = recordIsPartial ? (hydratedEventRequest ?? rawEventRequest) : rawEventRequest;
 
@@ -906,8 +910,22 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
     // toolkit, follow-up) with blanks.
     if (recordIsPartial && !hydratedEventRequest) {
       setIsSubmitting(false);
-      logger.log('⛔ Save blocked: full record not hydrated yet');
-      toast({ title: 'Loading full event…', description: 'Please wait a moment for the full event to load before saving.', variant: 'destructive' });
+      if (hydrationFailed) {
+        // The full-record fetch failed (not just still loading). Don't leave the
+        // user stuck behind a "loading" message — retry and tell them plainly.
+        // Saving stays blocked so a partial payload can't overwrite real data.
+        logger.log('⛔ Save blocked: full event failed to load; retrying');
+        refetchHydration();
+        toast({
+          title: "Couldn't load this event",
+          description: "We couldn't load the full event details, so saving is paused to avoid overwriting data. Retrying now — try again in a moment, or reopen it from the list.",
+          variant: 'destructive',
+          duration: Number.POSITIVE_INFINITY,
+        });
+      } else {
+        logger.log('⛔ Save blocked: full record not hydrated yet');
+        toast({ title: 'Loading full event…', description: 'Please wait a moment for the full event to load before saving.', variant: 'destructive' });
+      }
       return;
     }
 


### PR DESCRIPTION
Follow-up to **#426** (merged), addressing the two Bugbot findings on the partial-record hydration code that landed before the PR merged.

## Context
#426 made the scheduling form hydrate a *partial* record (e.g. opened from the map, which returns a subset of columns) to the full record before saving, so a full-form save can't blank the omitted fields. Bugbot flagged two rough edges in that hydration:

## Fixes
1. **Hydration fetch failure no longer stalls the save.** If the full-record `GET` *errors* (network blip) rather than just loading, `performSubmit` now retries the fetch and shows a clear, sticky message instead of an indefinite "Loading full event…". Saving stays blocked so a partial payload still can't overwrite real data — it just gives the user a path forward.
2. **Always-fresh hydration (no stale cache).** The hydration query reads `['/api/event-requests', id, 'full']`, but surgical saves no longer write that key — so a cached copy could be stale when reopening from the map. Added `staleTime: 0` + `refetchOnMount: 'always'` so it always fetches fresh on open.

## Safety
- **No net-new TypeScript errors** (project total unchanged at 1513).
- `mark-scheduled-save` regression suite passes (9/9).
- Behavior-preserving for the normal (list) flow — that path skips hydration entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwCxdLZ58uWtVqNFjA8TUc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the save gate for map-opened events to prevent data loss from partial/stale payloads; list flow is unchanged but incorrect blocking could frustrate users.
> 
> **Overview**
> Tightens **partial-record hydration** in `EventSchedulingForm` when an event is opened from the map (subset of columns) so full-form saves cannot run on incomplete or stale data.
> 
> The hydration query now uses **`staleTime: 0`** and **`refetchOnMount: 'always'`** so reopening the dialog always fetches a fresh full record instead of relying on a cached `…/full` entry that surgical saves no longer update.
> 
> **Save blocking** in `performSubmit` now also applies while hydration is **in flight** or **failed** (not only before the first successful load), avoiding saves built from stale cache shown during background refetch. On fetch **error**, the form **retries** via `refetchHydration()` and shows a **sticky** destructive toast explaining that save is paused to prevent overwriting data; the loading toast path remains for in-progress hydration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b11876bedd7ff359123cff90fb73773774e9dbed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->