### PR TITLE
Hotfix: missing getEffectiveEventDate import crashes Send Toolkit / event editing

### DIFF
--- a/client/src/components/event-email-composer.tsx
+++ b/client/src/components/event-email-composer.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import DOMPurify from 'dompurify';
+import { getEffectiveEventDate } from '@shared/event-validation-utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/client/src/components/event-requests/FollowUpDialog.tsx
+++ b/client/src/components/event-requests/FollowUpDialog.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-mobile';
 import type { EventRequest } from '@shared/schema';
+import { getEffectiveEventDate } from '@shared/event-validation-utils';
 
 // Follow-up Dialog Component
 interface FollowUpDialogProps {


### PR DESCRIPTION
## 🔴 Production hotfix

**Symptom:** Clicking **Send Toolkit** or **Edit Event** showed "Event Requests Unavailable / refresh" (the ErrorBoundary fallback), and users couldn't move events **new → in_process**.

**Console error:**
```
ReferenceError: getEffectiveEventDate is not defined
```

**Root cause:** The date-handling refactor (`f35b43e`) switched two components to `getEffectiveEventDate()` but never added the import:
- `client/src/components/event-email-composer.tsx` (Send Toolkit / email)
- `client/src/components/event-requests/FollowUpDialog.tsx`

When either renders, it throws — and because the event-requests section is wrapped in an ErrorBoundary, the whole section goes down, blocking the status change. The Vite production build doesn't typecheck, and the matching `tsc` error sat among the repo's known pre-existing errors, so it shipped unnoticed.

**Fix:** add the missing `import { getEffectiveEventDate } from '@shared/event-validation-utils'` to both files.

**Verification:**
- Swept all 45 files using the helper — these were the only two missing the import; none remain.
- `tsc` no longer reports `Cannot find name 'getEffectiveEventDate'`.

**The server status-transition rule was never the problem** — `new → in_process` is valid and requires no reason. The block was entirely this client crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwCxdLZ58uWtVqNFjA8TUc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only fix with no logic changes; low risk and directly reduces production crash surface on event-request workflows.
> 
> **Overview**
> Adds the missing `import { getEffectiveEventDate } from '@shared/event-validation-utils'` in **`event-email-composer.tsx`** (Send Toolkit / event email) and **`FollowUpDialog.tsx`** (follow-up dialogs).
> 
> A prior date refactor already called `getEffectiveEventDate` in those files without wiring the import, which caused a runtime **`ReferenceError`** when either UI opened and could take down the whole event-requests area behind the ErrorBoundary (e.g. blocking **Send Toolkit**, **Edit Event**, and **new → in_process** workflows). No behavior change beyond restoring those flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44773ab66f8eca0b4763788fbbf1defa5c0b85e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->