### PR TITLE
Fix lurking "Cannot find name" runtime crashes in event-requests UI

### DIFF
--- a/client/src/components/GuidedTour.tsx
+++ b/client/src/components/GuidedTour.tsx
@@ -7,6 +7,7 @@ import {
   Search,
   FolderOpen,
   Calendar,
+  Clock,
   BarChart3,
   ListTodo,
   Users,

--- a/client/src/components/event-requests/cards/InProcessCard.tsx
+++ b/client/src/components/event-requests/cards/InProcessCard.tsx
@@ -172,6 +172,7 @@ const CardHeader: React.FC<CardHeaderProps> = ({
   returningOrgData,
   onAddNextAction,
 }) => {
+  const { setViewMode } = useEventRequestContext();
   const isMobile = useIsMobile();
   const StatusIcon =
     statusIcons[request.status as keyof typeof statusIcons] || statusIcons.new;

--- a/client/src/components/event-requests/cards/NewRequestCard.tsx
+++ b/client/src/components/event-requests/cards/NewRequestCard.tsx
@@ -223,6 +223,7 @@ const CardHeader: React.FC<CardHeaderProps> = ({
   datePopulationInfo,
   returningOrgData,
 }) => {
+  const { setViewMode } = useEventRequestContext();
   const StatusIcon = statusIcons[request.status as keyof typeof statusIcons] || statusIcons.new;
   
   // Get the proper status label from constants instead of just replacing underscores

--- a/client/src/components/event-requests/form-sections/NotesSection.tsx
+++ b/client/src/components/event-requests/form-sections/NotesSection.tsx
@@ -72,7 +72,6 @@ export const NotesSection: React.FC<NotesSectionProps> = ({
                 value={formData.message}
                 onChange={(e) => {
                   const value = e.target.value;
-                  setLastNotesEditValue(value);
                   setFormData((prev: any) => ({ ...prev, message: value }));
                 }}
                 placeholder="Original request message from the organizer"

--- a/client/src/components/event-requests/tabs/InProcessTab.tsx
+++ b/client/src/components/event-requests/tabs/InProcessTab.tsx
@@ -192,7 +192,7 @@ export const InProcessTab: React.FC = () => {
           if (editingField.startsWith('partnerOrg_')) {
             // Editing a single partner organization (name + optional department)
             const index = parseInt(editingField.split('_')[1]);
-            const currentEvent = eventRequests.find(r => r.id === editingInProcessId);
+            const currentEvent = inProcessRequests.find(r => r.id === editingInProcessId);
             const currentPartners = Array.isArray(currentEvent?.partnerOrganizations) 
               ? (currentEvent.partnerOrganizations as any[]) 
               : [];

--- a/client/src/components/event-requests/tabs/NewRequestsTab.tsx
+++ b/client/src/components/event-requests/tabs/NewRequestsTab.tsx
@@ -127,7 +127,7 @@ export const NewRequestsTab: React.FC = () => {
           if (editingField.startsWith('partnerOrg_')) {
             // Editing a single partner organization (name + optional department)
             const index = parseInt(editingField.split('_')[1]);
-            const currentEvent = eventRequests.find(r => r.id === editingNewRequestId);
+            const currentEvent = newRequests.find(r => r.id === editingNewRequestId);
             const currentPartners = Array.isArray(currentEvent?.partnerOrganizations) 
               ? (currentEvent.partnerOrganizations as any[]) 
               : [];


### PR DESCRIPTION
Follow-up to the `getEffectiveEventDate` hotfix (#432). I swept the client for the **same bug class** — identifiers used but never defined, which the Vite build doesn't catch and only throw at runtime (and can trip the event-requests ErrorBoundary, "Event Requests Unavailable"). These are the confirmed, user-reachable ones:

| File | Crash trigger | Fix |
|------|---------------|-----|
| `NewRequestCard.tsx` | clicking a date-conflict badge ("N scheduled" / "N in process") | `setViewMode` was called in the `CardHeader` sub-component where it wasn't in scope → pull from `useEventRequestContext()` |
| `InProcessCard.tsx` | same date-conflict badges | same fix |
| `NewRequestsTab.tsx` | inline-editing a partner organization | undefined `eventRequests` → use `newRequests` |
| `InProcessTab.tsx` | inline-editing a partner organization | undefined `eventRequests` → use `inProcessRequests` |
| `GuidedTour.tsx` | rendering a tour step with a clock icon | `<Clock>` used without importing it from `lucide-react` |
| `NotesSection.tsx` | typing in the request-message field | dangling `setLastNotesEditValue()` (defined nowhere) → removed; `formData` update unchanged |

**Not included:** `CompletedCard`'s `CardAssignments` has the same pattern but is **dead code** (never rendered), so it can't crash a user — left as-is.

**Verification:**
- `tsc` errors dropped **1513 → 1503**, no new errors introduced (remaining errors in these files are pre-existing baseline noise).
- Production build is **green** (`npm run build` exit 0).

Note: these are pre-existing latent crashes (each behind a specific action), unrelated to today's incident except by sharing its root cause — a production build that doesn't typecheck. A narrowly-scoped CI gate on "Cannot find name"/undefined-reference errors would prevent this whole class; happy to add that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwCxdLZ58uWtVqNFjA8TUc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized bug fixes with no auth, API, or data-model changes; behavior is restoring intended interactions that previously crashed.
> 
> **Overview**
> Fixes **latent runtime crashes** in event-requests and guided tour UI where identifiers were used but never defined—errors Vite production builds don’t catch until a specific user action.
> 
> **New / in-process cards:** Nested `CardHeader` components now call `useEventRequestContext()` for **`setViewMode`**, so clicking date-population badges (“N scheduled” / “N in process”) switches to calendar view instead of throwing.
> 
> **Tab inline edits:** Partner-organization saves in **`NewRequestsTab`** and **`InProcessTab`** look up the current row from **`newRequests`** / **`inProcessRequests`** instead of undefined **`eventRequests`**.
> 
> **Notes & tour:** **`NotesSection`** drops a call to nonexistent **`setLastNotesEditValue`** when editing the initial message ( **`formData`** update unchanged). **`GuidedTour`** imports **`Clock`** from `lucide-react` for estimated-time display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 634524f7576cb0fbbec31b5d48926b422a718f90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->