### PR TITLE
Unify in-process follow-up signaling into one header badge

### DIFF
--- a/client/src/components/event-requests/LastContactAgeBadge.tsx
+++ b/client/src/components/event-requests/LastContactAgeBadge.tsx
@@ -124,7 +124,7 @@ export function LastContactAgeBadge({ request, className = '' }: LastContactAgeB
 
   const style = TIER_STYLES[ageBadge.tier];
   const tooltipText = lastTs
-    ? `Last contact attempt: ${lastTs.toLocaleDateString()} (${ageBadge.weeks} week${ageBadge.weeks === 1 ? '' : 's'} ago)`
+    ? `Last contact attempt: ${lastTs.toLocaleDateString()} (${ageBadge.weeks} week${ageBadge.weeks === 1 ? '' : 's'} ago) — follow-up needed`
     : ageBadge.label;
 
   return (
@@ -137,7 +137,7 @@ export function LastContactAgeBadge({ request, className = '' }: LastContactAgeB
             data-testid="badge-last-contact-age"
           >
             <AlertTriangle className="w-3 h-3" />
-            {ageBadge.label}
+            {ageBadge.label} · follow-up needed
           </Badge>
         </TooltipTrigger>
         <TooltipContent>

--- a/client/src/components/event-requests/cards/InProcessCard.tsx
+++ b/client/src/components/event-requests/cards/InProcessCard.tsx
@@ -1058,21 +1058,6 @@ export const InProcessCard: React.FC<InProcessCardProps> = ({
                   </span>
                 )}
               </div>
-              {followUpStatus === 'toolkit' && (
-                <div className="mt-2">
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Badge className="bg-[#A31C41] text-white border-[#A31C41] px-3 py-1 cursor-help">
-                        <AlertTriangle className="w-4 h-4 mr-1" />
-                        Follow-up needed - Over 1 week since toolkit sent
-                      </Badge>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>{indicatorTooltips.toolkitFollowUp}</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              )}
             </div>
           );
         })()}

--- a/client/src/components/event-requests/cards/InProcessCard.tsx
+++ b/client/src/components/event-requests/cards/InProcessCard.tsx
@@ -89,7 +89,6 @@ interface InProcessCardProps {
   request: EventRequest;
   resolveUserName?: (id: string) => string;
   isStale?: boolean;
-  followUpStatus?: 'toolkit' | 'contact' | null;
   onEdit: () => void;
   onDelete: () => void;
   onSchedule: () => void;
@@ -941,7 +940,6 @@ export const InProcessCard: React.FC<InProcessCardProps> = ({
   request,
   resolveUserName,
   isStale = false,
-  followUpStatus = null,
   onEdit,
   onDelete,
   onSchedule,

--- a/client/src/components/event-requests/tabs/InProcessTab.tsx
+++ b/client/src/components/event-requests/tabs/InProcessTab.tsx
@@ -396,7 +396,6 @@ export const InProcessTab: React.FC = () => {
               request={request}
               resolveUserName={resolveUserName}
               isStale={isStale(request)}
-              followUpStatus={getFollowUpStatus(request)}
               onEdit={() => {
                 setSelectedEventRequest(request);
                 setIsEditing(true);


### PR DESCRIPTION
Follow-up to #435, addressing the inconsistent follow-up signaling you spotted across in-process cards.

## The problem
`getFollowUpStatus` makes the two follow-up cases mutually exclusive, but they were signaled inconsistently:

| Event state | Before |
|---|---|
| **Contacted ≥ 1 wk ago** | only "Last contact 1 wk ago" — **no** follow-up wording |
| **No contact + toolkit ≥ 1 wk** | header **"Needs follow-up"** badge **and** a separate maroon "Follow-up needed - Over 1 week since toolkit sent" badge stuck down in the toolkit-sent section — **duplicative + odd placement** |

## The fix — one follow-up signal per card, in the header badge row
- **Contacted-but-stale:** `LastContactAgeBadge` now appends **"· follow-up needed"** to its stale label (and the tooltip), so it reads as an action item, not just an age.
- **Toolkit/no-contact:** removed the redundant, awkwardly-placed maroon toolkit badge. The header **"Needs follow-up"** badge — which fires for exactly this case (`isInProcessStale` === the toolkit case) — already covers it, in a sensible spot. The toolkit-sent date still shows as informational.

Net result: every in-process card shows a single, consistent, brand-colored follow-up signal up in the header row.

Build green; the `undefined-refs` gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwCxdLZ58uWtVqNFjA8TUc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and badge placement only in event-request UI; no API, auth, or data-model changes.
> 
> **Overview**
> **In-process cards** now use one consistent follow-up cue in the header badge row instead of mixed wording and duplicate badges.
> 
> For **stale contact** (last attempt ≥ 1 week), `LastContactAgeBadge` appends **"· follow-up needed"** on the badge and in the tooltip so the age reads as an action, not only history.
> 
> For **toolkit sent with no recent contact**, the extra maroon **"Follow-up needed - Over 1 week since toolkit sent"** block under the toolkit-sent line is removed. The header **"Needs follow-up"** badge (driven by existing `isStale` / toolkit logic) remains; toolkit-sent date stays informational only.
> 
> The unused `followUpStatus` prop is dropped from `InProcessCard` and is no longer passed from `InProcessTab`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e06b3ef0fc60d57b148689a5fc2d8bb2a52bfe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->