### PR TITLE
Schema + migration: next-follow-up coercion + TSP-shopped event fields

### DIFF
--- a/migrations/20260619_add_followup_date_and_tsp_shopped_fields.sql
+++ b/migrations/20260619_add_followup_date_and_tsp_shopped_fields.sql
@@ -1,0 +1,28 @@
+-- Adds two feature field groups to event_requests.
+-- Run against BOTH Neon branches (dev + production). Idempotent.
+
+-- Feature 1: "next follow-up date" suppression.
+-- The next_follow_up_date column ALREADY EXISTS in event_requests (it was added
+-- previously as "scheduled next attempt date"); Feature 1 reuses it. This
+-- IF NOT EXISTS is a safe no-op / drift guard and will do nothing on a DB that
+-- already has the column.
+ALTER TABLE event_requests
+  ADD COLUMN IF NOT EXISTS next_follow_up_date timestamp;
+
+-- Feature 2: TSP-shopped events (TSP buys the supplies for the group for a fee).
+ALTER TABLE event_requests
+  ADD COLUMN IF NOT EXISTS is_tsp_shopped boolean DEFAULT false;
+ALTER TABLE event_requests
+  ADD COLUMN IF NOT EXISTS tsp_shop_fee_agreed boolean DEFAULT false;
+ALTER TABLE event_requests
+  ADD COLUMN IF NOT EXISTS tsp_shop_estimate_provided boolean DEFAULT false;
+ALTER TABLE event_requests
+  ADD COLUMN IF NOT EXISTS tsp_shop_estimate_amount numeric(10, 2);
+ALTER TABLE event_requests
+  ADD COLUMN IF NOT EXISTS tsp_shop_paid boolean DEFAULT false;
+ALTER TABLE event_requests
+  ADD COLUMN IF NOT EXISTS tsp_shop_amount_paid numeric(10, 2);
+ALTER TABLE event_requests
+  ADD COLUMN IF NOT EXISTS tsp_shop_plan_ready boolean DEFAULT false;
+ALTER TABLE event_requests
+  ADD COLUMN IF NOT EXISTS tsp_shopping_plan text;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -3152,7 +3152,10 @@ export const insertEventRequestSchema = createInsertSchema(eventRequests)
             if (!/^\d{4}-\d{2}-\d{2}$/.test(str)) {
               throw new Error('Invalid date format, expected YYYY-MM-DD');
             }
-            const date = new Date(str);
+            // Parse at local noon (NOT bare `new Date(str)`, which is midnight UTC
+            // and renders/compares a day early in America/New_York). Mirrors the
+            // toolkitSentDate coercion above.
+            const date = new Date(str + 'T12:00:00');
             return isNaN(date.getTime()) ? null : date;
           }),
         z.null(),

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -2443,6 +2443,17 @@ export const eventRequests = pgTable(
     toolkitSentDate: timestamp('toolkit_sent_date'), // When toolkit was sent
     toolkitStatus: varchar('toolkit_status').default('not_sent'), // 'not_sent', 'sent', 'received_confirmed', 'not_needed'
     toolkitSentBy: varchar('toolkit_sent_by'), // User ID of who sent the toolkit
+
+    // TSP-shopped events: TSP purchases the supplies for the group for a fee + admin/donation
+    // (instead of the group shopping). Designation + tracking checklist + shopping plan.
+    isTspShopped: boolean('is_tsp_shopped').default(false), // Marks this as a TSP-shopped event
+    tspShopFeeAgreed: boolean('tsp_shop_fee_agreed').default(false), // Group notified of the fee and agreed
+    tspShopEstimateProvided: boolean('tsp_shop_estimate_provided').default(false), // Group given a budget/estimate
+    tspShopEstimateAmount: decimal('tsp_shop_estimate_amount', { precision: 10, scale: 2 }), // Estimated supplies + fee total
+    tspShopPaid: boolean('tsp_shop_paid').default(false), // Group has paid TSP (supplies + fee)
+    tspShopAmountPaid: decimal('tsp_shop_amount_paid', { precision: 10, scale: 2 }), // Amount the group actually paid
+    tspShopPlanReady: boolean('tsp_shop_plan_ready').default(false), // TSP has a plan to shop the supplies
+    tspShoppingPlan: text('tsp_shopping_plan'), // The shopping plan; shows on the card and flows to the planning sheet "All Details" column
     eventStartTime: varchar('event_start_time'), // Event start time (stored as string for flexibility)
     eventEndTime: varchar('event_end_time'), // Event end time
     pickupTime: varchar('pickup_time'), // Driver pickup time for sandwiches
@@ -3129,6 +3140,34 @@ export const insertEventRequestSchema = createInsertSchema(eventRequests)
       ])
       .nullable()
       .optional(),
+    // Optional next-follow-up date (suppresses follow-up nagging for long-lead events)
+    nextFollowUpDate: z
+      .union([
+        z.date(),
+        z
+          .string()
+          .trim()
+          .transform((str) => {
+            if (!str) return null;
+            if (!/^\d{4}-\d{2}-\d{2}$/.test(str)) {
+              throw new Error('Invalid date format, expected YYYY-MM-DD');
+            }
+            const date = new Date(str);
+            return isNaN(date.getTime()) ? null : date;
+          }),
+        z.null(),
+      ])
+      .nullable()
+      .optional(),
+    // TSP-shopped event fields
+    isTspShopped: z.boolean().nullable().optional(),
+    tspShopFeeAgreed: z.boolean().nullable().optional(),
+    tspShopEstimateProvided: z.boolean().nullable().optional(),
+    tspShopEstimateAmount: z.union([z.string(), z.number(), z.null()]).optional(),
+    tspShopPaid: z.boolean().nullable().optional(),
+    tspShopAmountPaid: z.union([z.string(), z.number(), z.null()]).optional(),
+    tspShopPlanReady: z.boolean().nullable().optional(),
+    tspShoppingPlan: z.string().nullable().optional(),
     followUpOneDayCompleted: z.boolean().nullable().optional(),
     followUpOneDayDate: z
       .union([


### PR DESCRIPTION
**PR 1 of the two-feature series** (schema + migration only — no behavior change yet).

## Feature 1 — long-lead follow-up suppression
While wiring this up I found `event_requests.nextFollowUpDate` (column `next_follow_up_date`, "scheduled next attempt date") **already exists** and is already in the PATCH allowlist — so **no new column is needed**, Feature 1 reuses it. I only added a **Zod date-coercion override** (`Date | YYYY-MM-DD string | null`) since the existing field had none. The suppression logic + form input come in the Feature 1 PR.

## Feature 2 — TSP-shopped events
New columns on `event_requests`:
- `is_tsp_shopped` (bool)
- `tsp_shop_fee_agreed` (bool)
- `tsp_shop_estimate_provided` (bool) + `tsp_shop_estimate_amount` (numeric 10,2)
- `tsp_shop_paid` (bool) + `tsp_shop_amount_paid` (numeric 10,2)
- `tsp_shop_plan_ready` (bool)
- `tsp_shopping_plan` (text)

…plus matching Zod entries. UI + planning-sheet wiring come in later PRs.

## Migration
`migrations/20260619_add_followup_date_and_tsp_shopped_fields.sql` — adds the TSP columns; the `next_follow_up_date` line is `ADD COLUMN IF NOT EXISTS` (safe no-op / drift guard since it already exists).

⚠️ **Action after merge:** run this migration on **both Neon branches (dev + production)** before the feature PRs land — they'll read/write these columns.

No new TypeScript errors beyond the pre-existing baseline; build green; `undefined-refs` gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwCxdLZ58uWtVqNFjA8TUc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive nullable/defaulted columns and validation only; risk is mainly operational—migration must be applied on dev and production before dependent PRs land.
> 
> **Overview**
> **Schema-only groundwork** for two upcoming features on `event_requests`: long-lead follow-up scheduling (reusing existing `next_follow_up_date`) and TSP-shopped events (new tracking fields). No app behavior changes in this PR.
> 
> Adds an idempotent migration that guards `next_follow_up_date` with `ADD COLUMN IF NOT EXISTS` and introduces **seven TSP-shopping columns** (`is_tsp_shopped`, fee/estimate/paid booleans, numeric amounts, plan-ready flag, and `tsp_shopping_plan` text), with matching Drizzle definitions on the event request model.
> 
> Extends the event-request **PATCH Zod schema** with `nextFollowUpDate` coercion (`Date`, `YYYY-MM-DD`, or `null`) using local-noon parsing to avoid UTC day-shift, plus optional validators for all new TSP-shopped fields.
> 
> **After merge:** run the migration on **both Neon dev and production** before follow-up feature PRs that read/write these columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fc78d8e6e5cdc6a2205921894f09357c6f49dc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->