### PR TITLE
Fix manual event creation: tolerate email whitespace, never require email/phone, allow blank entries

### DIFF
--- a/client/src/components/event-requests/form-utils.ts
+++ b/client/src/components/event-requests/form-utils.ts
@@ -117,7 +117,7 @@ export function buildEventDataForServer(
     // Contact information
     firstName: formData.firstName || null,
     lastName: formData.lastName || null,
-    email: formData.email || null,
+    email: formData.email?.trim() || null,
     phone: formData.phone || null,
     organizationName: formData.organizationName || null,
     department: formData.department || null,

--- a/server/routes/event-requests-legacy.ts
+++ b/server/routes/event-requests-legacy.ts
@@ -1763,13 +1763,23 @@ router.post(
       try {
         validatedData = insertEventRequestSchema.parse(requestData);
       } catch (validationError: unknown) {
-        const errorDetails = validationError instanceof z.ZodError
-          ? validationError.errors
+        const zodError = validationError instanceof z.ZodError ? validationError : null;
+        const errorDetails = zodError
+          ? zodError.errors
           : (validationError as Error).message;
+        // Surface the ACTUAL field-level problem (e.g. an invalid email) instead
+        // of the generic org-name message — that message made real validation
+        // failures look unexplained, since the user had already entered an org name.
+        const firstIssue = zodError?.errors?.[0];
+        const specificMessage = firstIssue
+          ? (firstIssue.path?.length
+              ? `${firstIssue.message} (field: ${firstIssue.path.join('.')})`
+              : firstIssue.message)
+          : null;
         return res.status(400).json({
           error: 'Validation failed',
           details: errorDetails,
-          message: 'Please check your input and try again. Make sure you provide at least an organization name or contact information.'
+          message: specificMessage || 'Please check your input and try again. Make sure you provide at least an organization name or contact information.'
         });
       }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -3241,27 +3241,11 @@ export const insertEventRequestSchema = createInsertSchema(eventRequests)
         z.null(),
       ])
       .optional(),
-  })
-  .refine(
-    (data) => {
-      // Require at least ONE identifier so the record isn't completely blank,
-      // but never require email or phone specifically — any single field is
-      // enough (org name, a contact name, email, OR phone).
-      const hasOrgName =
-        data.organizationName && data.organizationName.trim().length > 0;
-      const hasContactInfo =
-        (data.firstName && data.firstName.trim().length > 0) ||
-        (data.lastName && data.lastName.trim().length > 0) ||
-        (data.email && data.email.trim().length > 0) ||
-        (data.phone && data.phone.trim().length > 0);
-      return hasOrgName || hasContactInfo;
-    },
-    {
-      message:
-        'Please enter at least one of: organization name, contact name, email, or phone.',
-      path: ['organizationName'],
-    }
-  );
+  });
+// NOTE: No "must have at least one identifier" refine. Manual entries are
+// intentionally allowed to be created fully blank (no org name, contact name,
+// email, or phone) and filled in later as intake details come in. Email format
+// is still validated when an email IS provided (see the `email` field above).
 
 export const insertEventReminderSchema = createInsertSchema(eventReminders)
   .omit({

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -3244,18 +3244,21 @@ export const insertEventRequestSchema = createInsertSchema(eventRequests)
   })
   .refine(
     (data) => {
-      // Require at least organization name OR some contact information
+      // Require at least ONE identifier so the record isn't completely blank,
+      // but never require email or phone specifically — any single field is
+      // enough (org name, a contact name, email, OR phone).
       const hasOrgName =
         data.organizationName && data.organizationName.trim().length > 0;
       const hasContactInfo =
         (data.firstName && data.firstName.trim().length > 0) ||
         (data.lastName && data.lastName.trim().length > 0) ||
-        (data.email && data.email.trim().length > 0);
+        (data.email && data.email.trim().length > 0) ||
+        (data.phone && data.phone.trim().length > 0);
       return hasOrgName || hasContactInfo;
     },
     {
       message:
-        'Either organization name or contact information (name/email) is required',
+        'Please enter at least one of: organization name, contact name, email, or phone.',
       path: ['organizationName'],
     }
   );

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -3031,8 +3031,21 @@ export const insertEventRequestSchema = createInsertSchema(eventRequests)
     firstName: z.string().nullable().optional(),
     lastName: z.string().nullable().optional(),
     email: z
-      .union([z.string().email(), z.literal(''), z.null(), z.undefined()])
-      .transform((val) => val || undefined)
+      .union([z.string(), z.null(), z.undefined()])
+      // Trim first: a pasted address with leading/trailing whitespace (or a
+      // stray newline) is the most common reason a manual event silently fails
+      // to save. Empty/whitespace-only becomes undefined so the field is simply
+      // omitted, matching the previous behavior.
+      .transform((val) => {
+        const trimmed = typeof val === 'string' ? val.trim() : '';
+        return trimmed.length > 0 ? trimmed : undefined;
+      })
+      // Only enforce email format when a value is actually present, with a clear
+      // message (the create endpoint surfaces this to the user).
+      .refine(
+        (val) => val === undefined || z.string().email().safeParse(val).success,
+        { message: 'Please enter a valid email address (e.g., name@example.com).' }
+      )
       .optional(),
     organizationName: z.string().nullable().optional(),
     manualEntrySource: z.string().nullable().optional(),


### PR DESCRIPTION
Three related fixes to manual event creation (`POST /api/event-requests`).

## 1. Silent failure on whitespace / invalid email (the original bug)
Manual entries weren't saving when fully filled out, but a barebones one saved fine. Cause: the create endpoint validates with `insertEventRequestSchema`, whose `email` field required a perfectly-valid address with **no trimming**. A pasted email with a leading/trailing space or newline (or any malformed address) failed the *entire* `parse()` → 400 → event didn't save. The edit/update (PATCH) path doesn't run this validation, so it was create-only.

The error message made it worse: it returned a generic *"make sure you provide an organization name or contact information,"* so a bad email looked unexplained.

**Fix:**
- `shared/schema.ts` — trim email before validating; empty/whitespace-only → omitted; only enforce format when a value is present, with a clear message *"Please enter a valid email address (e.g., name@example.com)."*
- `form-utils.ts` — trim email before sending (covers create + edit).
- create handler — surface the actual field-level message instead of the misleading org-name one.

## 2. Email & phone never required
Email/phone were already optional, but a **phone-only** entry was rejected because phone wasn't counted as an identifier. (Now superseded by #3.)

## 3. Allow fully-blank manual entries
Removed the "must have at least one identifier" rule entirely — a manual entry can now be created **completely empty** and filled in later as intake details come in. Email format is still validated when an email *is* provided.

## Verification (against the real validator)
| input | result |
|---|---|
| `" jane@company.com"` / `"...\n"` (whitespace) | ✅ trimmed & saved |
| completely blank entry | ✅ saved |
| org-name-only / phone-only / name-only / email-only | ✅ saved |
| `jane` / `jane@company` (bad email, when entered) | ❌ clear "valid email" message |

Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes create validation (blank manual entries allowed) and changes shared schema behavior for all creates using `insertEventRequestSchema`; email handling is low-risk but the identifier rule removal is a product/intake policy change.
> 
> **Overview**
> Fixes **manual event create** failing when a pasted email has leading/trailing whitespace or invalid format, while barebones creates (no email) still worked.
> 
> **`insertEventRequestSchema`** now **trims** email, treats blank/whitespace as omitted, validates format only when a value is present (clear error message), and **drops** the schema-level rule requiring org name or contact info so fully blank manual stubs can be created.
> 
> **`buildEventDataForServer`** trims email before send (create and edit).
> 
> **`POST /api/event-requests`** returns the first Zod issue (with field path) instead of the generic org/contact message on validation failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4be293a63d41597a72b6faa7628dae2ff470d5f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->