### PR TITLE
Add "You're in!" confirmation dialog with calendar export after signup

### DIFF
--- a/client/src/lib/calendar-links.ts
+++ b/client/src/lib/calendar-links.ts
@@ -12,7 +12,7 @@
  * from the date's UTC parts so it never drifts a day early.
  */
 
-const APP_TIMEZONE = 'America/New_York';
+import { APP_TIMEZONE } from '@/lib/date-utils';
 
 /**
  * Offset (in ms) of the app timezone from UTC at a given instant.

--- a/client/src/lib/calendar-links.ts
+++ b/client/src/lib/calendar-links.ts
@@ -1,0 +1,141 @@
+/**
+ * Client-side calendar link helpers for the Volunteer Hub.
+ *
+ * These mirror the server-side helpers in server/routes/volunteer-event-hub.ts
+ * (used in approval emails) so the "Add to calendar" buttons shown right after
+ * signup behave identically to the links a volunteer later receives by email.
+ *
+ * Times are treated as UTC wall-clock (e.g. "10:00 AM" -> 10:00 UTC), matching
+ * the existing email behavior. This keeps the two code paths consistent.
+ */
+
+/**
+ * Parse "HH:MM" or "H:MM AM/PM" into a Date on the given day (UTC).
+ * Returns null if the time can't be parsed so callers can fall back to all-day.
+ */
+function combineDateAndTime(dateOnly: Date, time: string | null | undefined): Date | null {
+  if (!time) return null;
+  const m = time.trim().match(/^(\d{1,2}):(\d{2})\s*(AM|PM|am|pm)?$/);
+  if (!m) return null;
+  let hours = parseInt(m[1], 10);
+  const minutes = parseInt(m[2], 10);
+  const ampm = m[3]?.toUpperCase();
+  if (ampm === 'PM' && hours < 12) hours += 12;
+  if (ampm === 'AM' && hours === 12) hours = 0;
+  if (hours > 23 || minutes > 59) return null;
+  const out = new Date(dateOnly);
+  out.setUTCHours(hours, minutes, 0, 0);
+  return out;
+}
+
+function formatICalDate(d: Date, allDay: boolean): string {
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  if (allDay) return `${yyyy}${mm}${dd}`;
+  const hh = String(d.getUTCHours()).padStart(2, '0');
+  const mi = String(d.getUTCMinutes()).padStart(2, '0');
+  const ss = String(d.getUTCSeconds()).padStart(2, '0');
+  return `${yyyy}${mm}${dd}T${hh}${mi}${ss}Z`;
+}
+
+function escapeICS(text: string): string {
+  return text
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/,/g, '\\,')
+    .replace(/;/g, '\\;');
+}
+
+export interface EventTimes {
+  start: Date;
+  end: Date;
+  allDay: boolean;
+}
+
+/**
+ * Build start/end Dates from an event's date + start/end times.
+ * If a start time is missing, the event is treated as all-day.
+ * If only a start time is present, the event defaults to 2 hours long.
+ */
+export function buildEventTimes(
+  eventDate: string | Date | null | undefined,
+  startTime: string | null | undefined,
+  endTime: string | null | undefined,
+): EventTimes | null {
+  if (!eventDate) return null;
+  const dayDate = new Date(eventDate);
+  if (isNaN(dayDate.getTime())) return null;
+  const day = new Date(Date.UTC(dayDate.getUTCFullYear(), dayDate.getUTCMonth(), dayDate.getUTCDate()));
+  const start = combineDateAndTime(day, startTime);
+  const end = combineDateAndTime(day, endTime);
+  if (start && end) return { start, end, allDay: false };
+  if (start && !end) {
+    const fallbackEnd = new Date(start.getTime() + 2 * 60 * 60 * 1000);
+    return { start, end: fallbackEnd, allDay: false };
+  }
+  const nextDay = new Date(day.getTime() + 24 * 60 * 60 * 1000);
+  return { start: day, end: nextDay, allDay: true };
+}
+
+/** Build a Google Calendar "add event" deep link. */
+export function googleCalendarUrl(
+  title: string,
+  times: EventTimes,
+  location: string | null,
+  details: string | null,
+): string {
+  const dates = `${formatICalDate(times.start, times.allDay)}/${formatICalDate(times.end, times.allDay)}`;
+  const params = new URLSearchParams({ action: 'TEMPLATE', text: title, dates });
+  if (location) params.set('location', location);
+  if (details) params.set('details', details);
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}
+
+/** Build .ics file contents (for Apple Calendar / Outlook). */
+export function buildIcs(
+  uid: string,
+  title: string,
+  times: EventTimes,
+  location: string | null,
+  details: string | null,
+): string {
+  const dtstart = times.allDay
+    ? `DTSTART;VALUE=DATE:${formatICalDate(times.start, true)}`
+    : `DTSTART:${formatICalDate(times.start, false)}`;
+  const dtend = times.allDay
+    ? `DTEND;VALUE=DATE:${formatICalDate(times.end, true)}`
+    : `DTEND:${formatICalDate(times.end, false)}`;
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//The Sandwich Project//Volunteer Hub//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    'BEGIN:VEVENT',
+    `UID:${uid}`,
+    `DTSTAMP:${formatICalDate(new Date(), false)}`,
+    dtstart,
+    dtend,
+    `SUMMARY:${escapeICS(title)}`,
+    location ? `LOCATION:${escapeICS(location)}` : '',
+    details ? `DESCRIPTION:${escapeICS(details)}` : '',
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].filter(Boolean);
+  return lines.join('\r\n');
+}
+
+/** Trigger a browser download of an .ics file. */
+export function downloadIcs(filename: string, icsContent: string): void {
+  const blob = new Blob([icsContent], { type: 'text/calendar;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename.endsWith('.ics') ? filename : `${filename}.ics`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  // Revoke on the next tick so the click has a chance to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/client/src/lib/calendar-links.ts
+++ b/client/src/lib/calendar-links.ts
@@ -5,13 +5,68 @@
  * (used in approval emails) so the "Add to calendar" buttons shown right after
  * signup behave identically to the links a volunteer later receives by email.
  *
- * Times are treated as UTC wall-clock (e.g. "10:00 AM" -> 10:00 UTC), matching
- * the existing email behavior. This keeps the two code paths consistent.
+ * Event times are stored as Eastern Time (America/New_York) wall-clock strings
+ * (e.g. "10:00 AM" means 10am in Atlanta). We convert them to the correct UTC
+ * instant — accounting for EDT/EST — so a 10am event lands on the volunteer's
+ * calendar as 10am, not shifted by the timezone offset. The event *day* is taken
+ * from the date's UTC parts so it never drifts a day early.
  */
 
+const APP_TIMEZONE = 'America/New_York';
+
 /**
- * Parse "HH:MM" or "H:MM AM/PM" into a Date on the given day (UTC).
- * Returns null if the time can't be parsed so callers can fall back to all-day.
+ * Offset (in ms) of the app timezone from UTC at a given instant.
+ * Positive east of UTC; for Eastern it's negative (-4h EDT, -5h EST).
+ */
+function appTimezoneOffsetMs(date: Date): number {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: APP_TIMEZONE,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  const map: Record<string, string> = {};
+  for (const part of dtf.formatToParts(date)) {
+    if (part.type !== 'literal') map[part.type] = part.value;
+  }
+  let hour = Number(map.hour);
+  if (hour === 24) hour = 0; // some engines render midnight as 24
+  const asUtc = Date.UTC(
+    Number(map.year),
+    Number(map.month) - 1,
+    Number(map.day),
+    hour,
+    Number(map.minute),
+    Number(map.second),
+  );
+  return asUtc - date.getTime();
+}
+
+/**
+ * Convert an Eastern wall-clock time (the calendar day + h:mm) into the true UTC
+ * instant, handling daylight saving automatically.
+ */
+function easternWallClockToUtc(
+  year: number,
+  monthIndex: number,
+  day: number,
+  hours: number,
+  minutes: number,
+): Date {
+  // First approximation: pretend the wall clock is already UTC.
+  const guess = Date.UTC(year, monthIndex, day, hours, minutes, 0);
+  // Then shift by the zone's offset at (approximately) that instant.
+  return new Date(guess - appTimezoneOffsetMs(new Date(guess)));
+}
+
+/**
+ * Parse "HH:MM" or "H:MM AM/PM" into the true UTC Date for that Eastern
+ * wall-clock time on the given calendar day. Returns null if the time can't be
+ * parsed so callers can fall back to all-day.
  */
 function combineDateAndTime(dateOnly: Date, time: string | null | undefined): Date | null {
   if (!time) return null;
@@ -23,9 +78,14 @@ function combineDateAndTime(dateOnly: Date, time: string | null | undefined): Da
   if (ampm === 'PM' && hours < 12) hours += 12;
   if (ampm === 'AM' && hours === 12) hours = 0;
   if (hours > 23 || minutes > 59) return null;
-  const out = new Date(dateOnly);
-  out.setUTCHours(hours, minutes, 0, 0);
-  return out;
+  // dateOnly holds the intended calendar day in its UTC parts.
+  return easternWallClockToUtc(
+    dateOnly.getUTCFullYear(),
+    dateOnly.getUTCMonth(),
+    dateOnly.getUTCDate(),
+    hours,
+    minutes,
+  );
 }
 
 function formatICalDate(d: Date, allDay: boolean): string {

--- a/client/src/pages/volunteer-event-hub.tsx
+++ b/client/src/pages/volunteer-event-hub.tsx
@@ -1778,7 +1778,7 @@ export default function VolunteerEventHub() {
 
   // Signup mutation
   const signupMutation = useMutation({
-    mutationFn: async ({ eventId, roles, notes }: { eventId: number; roles: string[]; notes: string }) => {
+    mutationFn: async ({ eventId, roles, notes }: { eventId: number; event: AvailableEvent; roles: string[]; notes: string }) => {
       const response = await fetch(`/api/volunteer-hub/signup/${eventId}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -1792,19 +1792,12 @@ export default function VolunteerEventHub() {
       return response.json();
     },
     onSuccess: (_data, variables) => {
-      // Hand off to the celebratory "You're in!" dialog. Capture the event
-      // before clearing selection so the confirmation has its details.
-      const confirmedEvent = selectedEvent;
+      // Hand off to the celebratory "You're in!" dialog. Use the event captured
+      // in the mutation variables — not selectedEvent, which may have changed if
+      // the user clicked a different event while this request was in flight.
       setSignupDialogOpen(false);
       setSelectedEvent(null);
-      if (confirmedEvent) {
-        setSignupConfirmation({ event: confirmedEvent, roles: variables.roles });
-      } else {
-        toast({
-          title: "You're signed up! 🎉",
-          description: 'Thanks for volunteering. A coordinator will confirm your spot.',
-        });
-      }
+      setSignupConfirmation({ event: variables.event, roles: variables.roles });
       queryClient.invalidateQueries({ queryKey: ['/api/volunteer-hub/my-signups'] });
       queryClient.invalidateQueries({ queryKey: ['/api/volunteer-hub/available-events'] });
       queryClient.invalidateQueries({ queryKey: ['/api/volunteer-hub/coverage-summary'] });
@@ -2242,7 +2235,7 @@ export default function VolunteerEventHub() {
   // Handle signup submit
   const handleSignupSubmit = (roles: string[], notes: string) => {
     if (selectedEvent) {
-      signupMutation.mutate({ eventId: selectedEvent.id, roles, notes });
+      signupMutation.mutate({ eventId: selectedEvent.id, event: selectedEvent, roles, notes });
     }
   };
 

--- a/client/src/pages/volunteer-event-hub.tsx
+++ b/client/src/pages/volunteer-event-hub.tsx
@@ -87,8 +87,17 @@ import {
   CheckCircle2,
   LocateFixed,
   Ban,
+  PartyPopper,
+  CalendarPlus,
+  Download,
 } from 'lucide-react';
 import { getEffectiveEventDate } from '@shared/event-validation-utils';
+import {
+  buildEventTimes,
+  googleCalendarUrl,
+  buildIcs,
+  downloadIcs,
+} from '@/lib/calendar-links';
 
 // Fix Leaflet default marker icon
 delete (L.Icon.Default.prototype as any)._getIconUrl;
@@ -946,6 +955,172 @@ function SignupDialog({
   );
 }
 
+// Friendly labels for the roles a volunteer signed up for.
+const SIGNUP_ROLE_LABELS: Record<string, string> = {
+  speaker: 'Speaker',
+  general: 'General Volunteer',
+  driver: 'Driver',
+};
+
+function signupRoleLabel(role: string): string {
+  return SIGNUP_ROLE_LABELS[role] || role;
+}
+
+/**
+ * The "You're in!" moment. Shown immediately after a successful signup so the
+ * volunteer gets a clear, enthusiastic confirmation (this is the SignUpGenius
+ * replacement — it needs to feel reassuring, especially for non-tech users) plus
+ * a one-tap way to add the event to their calendar.
+ */
+function SignupSuccessDialog({
+  event,
+  roles,
+  open,
+  onOpenChange,
+}: {
+  event: AvailableEvent | null;
+  roles: string[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  if (!event) return null;
+
+  const eventDate = getEffectiveEventDate(event);
+  const parsedDate = eventDate ? parseEventDate(eventDate) : null;
+  const formattedDate = parsedDate ? format(parsedDate, 'EEEE, MMMM d') : 'a date to be confirmed';
+  const shortDate = parsedDate ? format(parsedDate, 'MMMM d') : 'TBD';
+  const timeText = formatEventTime(event.eventStartTime, event.eventEndTime);
+  const addressText = getAddressText(event);
+
+  const times = buildEventTimes(eventDate, event.eventStartTime, event.eventEndTime);
+  const calTitle = `Sandwich Project — ${event.organizationName}`;
+  const roleLabels = roles.map(signupRoleLabel);
+  const calDetails = [
+    roleLabels.length ? `Role${roleLabels.length > 1 ? 's' : ''}: ${roleLabels.join(', ')}` : null,
+    'Thanks for volunteering with The Sandwich Project!',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const handleGoogle = () => {
+    if (!times) return;
+    const url = googleCalendarUrl(calTitle, times, addressText || null, calDetails);
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  const handleIcs = () => {
+    if (!times) return;
+    const ics = buildIcs(
+      `tsp-volunteer-${event.id}@thesandwichproject.org`,
+      calTitle,
+      times,
+      addressText || null,
+      calDetails,
+    );
+    downloadIcs(`sandwich-project-${event.id}.ics`, ics);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader className="items-center text-center">
+          <div className="mx-auto mb-2 flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-[#007e8c] to-[#47b3cb] text-white shadow-sm">
+            <PartyPopper className="h-7 w-7" />
+          </div>
+          <DialogTitle className="text-xl">You're in! 🎉</DialogTitle>
+          <DialogDescription className="text-base text-[#236383]">
+            Thanks for signing up to volunteer at{' '}
+            <span className="font-semibold">{event.organizationName}</span> on{' '}
+            <span className="font-semibold">{shortDate}</span>.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Event recap */}
+          <div className="rounded-lg border border-[#007e8c]/20 bg-[#007e8c]/5 p-4 space-y-2.5 text-sm">
+            <div className="flex items-center gap-2 text-gray-700">
+              <Building2 className="h-4 w-4 shrink-0 text-[#007e8c]" />
+              <span className="font-medium">{event.organizationName}</span>
+            </div>
+            <div className="flex items-center gap-2 text-gray-700">
+              <CalendarDays className="h-4 w-4 shrink-0 text-[#007e8c]" />
+              <span>{formattedDate}</span>
+            </div>
+            <div className="flex items-center gap-2 text-gray-700">
+              <Clock className="h-4 w-4 shrink-0 text-[#007e8c]" />
+              <span>{timeText}</span>
+            </div>
+            {addressText && (
+              <div className="flex items-start gap-2 text-gray-700">
+                <MapPin className="h-4 w-4 shrink-0 text-[#007e8c] mt-0.5" />
+                <span>{addressText}</span>
+              </div>
+            )}
+            {roleLabels.length > 0 && (
+              <div className="flex flex-wrap items-center gap-1.5 pt-1">
+                {roleLabels.map((label) => (
+                  <Badge
+                    key={label}
+                    variant="secondary"
+                    className="bg-[#007e8c]/10 text-[#236383] hover:bg-[#007e8c]/10"
+                  >
+                    {label}
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Add to calendar */}
+          {times && (
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-muted-foreground">
+                Add it to your calendar so you don't forget:
+              </p>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Button
+                  variant="outline"
+                  onClick={handleGoogle}
+                  className="flex-1 border-[#007e8c]/30 text-[#236383] hover:bg-[#007e8c]/5"
+                >
+                  <CalendarPlus className="h-4 w-4 mr-2" />
+                  Google Calendar
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={handleIcs}
+                  className="flex-1 border-[#007e8c]/30 text-[#236383] hover:bg-[#007e8c]/5"
+                >
+                  <Download className="h-4 w-4 mr-2" />
+                  Apple / Outlook
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* What happens next */}
+          <div className="flex items-start gap-2 text-xs text-muted-foreground">
+            <CheckCircle2 className="h-4 w-4 shrink-0 text-[#007e8c] mt-0.5" />
+            <span>
+              A coordinator will confirm your spot, and we've emailed you the details. See you on{' '}
+              {shortDate}!
+            </span>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            onClick={() => onOpenChange(false)}
+            className="w-full bg-gradient-to-r from-[#007e8c] to-[#47b3cb] hover:from-[#236383] hover:to-[#007e8c] text-white"
+          >
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function UnavailableDialog({
   event,
   existingUnavailable,
@@ -1405,6 +1580,11 @@ export default function VolunteerEventHub() {
   const [selectedCalendarDate, setSelectedCalendarDate] = useState<string | null>(null);
   const [selectedEvent, setSelectedEvent] = useState<AvailableEvent | null>(null);
   const [signupDialogOpen, setSignupDialogOpen] = useState(false);
+  // "You're in!" confirmation shown after a successful self-signup.
+  const [signupConfirmation, setSignupConfirmation] = useState<{
+    event: AvailableEvent;
+    roles: string[];
+  } | null>(null);
   const [unavailableDialogOpen, setUnavailableDialogOpen] = useState(false);
   const [assignDialogOpen, setAssignDialogOpen] = useState(false);
   const [manageSignup, setManageSignup] = useState<any | null>(null);
@@ -1611,13 +1791,20 @@ export default function VolunteerEventHub() {
       }
       return response.json();
     },
-    onSuccess: (data) => {
-      toast({
-        title: 'Signup Submitted!',
-        description: data.message || 'Your volunteer request has been submitted.',
-      });
+    onSuccess: (_data, variables) => {
+      // Hand off to the celebratory "You're in!" dialog. Capture the event
+      // before clearing selection so the confirmation has its details.
+      const confirmedEvent = selectedEvent;
       setSignupDialogOpen(false);
       setSelectedEvent(null);
+      if (confirmedEvent) {
+        setSignupConfirmation({ event: confirmedEvent, roles: variables.roles });
+      } else {
+        toast({
+          title: "You're signed up! 🎉",
+          description: 'Thanks for volunteering. A coordinator will confirm your spot.',
+        });
+      }
       queryClient.invalidateQueries({ queryKey: ['/api/volunteer-hub/my-signups'] });
       queryClient.invalidateQueries({ queryKey: ['/api/volunteer-hub/available-events'] });
       queryClient.invalidateQueries({ queryKey: ['/api/volunteer-hub/coverage-summary'] });
@@ -3474,6 +3661,16 @@ export default function VolunteerEventHub() {
           isSubmitting={signupMutation.isPending}
           preselectedRole={preselectedSignupRole}
           userCapabilities={user as UserRoleCapabilities | null}
+        />
+
+        {/* "You're in!" confirmation shown right after a successful signup */}
+        <SignupSuccessDialog
+          event={signupConfirmation?.event ?? null}
+          roles={signupConfirmation?.roles ?? []}
+          open={signupConfirmation !== null}
+          onOpenChange={(isOpen) => {
+            if (!isOpen) setSignupConfirmation(null);
+          }}
         />
 
         <UnavailableDialog

--- a/server/routes/volunteer-event-hub.ts
+++ b/server/routes/volunteer-event-hub.ts
@@ -304,9 +304,61 @@ function displayRole(role: string | null | undefined): string {
   return ROLE_DISPLAY[role] || role;
 }
 
+const CALENDAR_TIMEZONE = 'America/New_York';
+
 /**
- * Parse "HH:MM" or "H:MM AM/PM" into a Date on the given dateOnly day (UTC).
- * If parsing fails, returns null so caller can fall back to all-day.
+ * Offset (in ms) of the app timezone from UTC at a given instant.
+ * For Eastern this is negative (-4h EDT, -5h EST).
+ */
+function calendarTimezoneOffsetMs(date: Date): number {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: CALENDAR_TIMEZONE,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  const map: Record<string, string> = {};
+  for (const part of dtf.formatToParts(date)) {
+    if (part.type !== 'literal') map[part.type] = part.value;
+  }
+  let hour = Number(map.hour);
+  if (hour === 24) hour = 0; // some engines render midnight as 24
+  const asUtc = Date.UTC(
+    Number(map.year),
+    Number(map.month) - 1,
+    Number(map.day),
+    hour,
+    Number(map.minute),
+    Number(map.second),
+  );
+  return asUtc - date.getTime();
+}
+
+/**
+ * Convert an Eastern wall-clock time (calendar day + h:mm) into the true UTC
+ * instant, handling daylight saving automatically.
+ */
+function easternWallClockToUtc(
+  year: number,
+  monthIndex: number,
+  day: number,
+  hours: number,
+  minutes: number,
+): Date {
+  const guess = Date.UTC(year, monthIndex, day, hours, minutes, 0);
+  return new Date(guess - calendarTimezoneOffsetMs(new Date(guess)));
+}
+
+/**
+ * Parse "HH:MM" or "H:MM AM/PM" into the true UTC Date for that Eastern
+ * wall-clock time on the given calendar day. Event times are stored as Eastern
+ * (America/New_York) wall-clock, so e.g. "10:00 AM" must land on a calendar as
+ * 10am Eastern — not 10:00 UTC, which would show as 6am. If parsing fails,
+ * returns null so caller can fall back to all-day.
  */
 function combineDateAndTime(dateOnly: Date, time: string | null | undefined): Date | null {
   if (!time) return null;
@@ -320,9 +372,14 @@ function combineDateAndTime(dateOnly: Date, time: string | null | undefined): Da
   if (ampm === 'PM' && hours < 12) hours += 12;
   if (ampm === 'AM' && hours === 12) hours = 0;
   if (hours > 23 || minutes > 59) return null;
-  const out = new Date(dateOnly);
-  out.setUTCHours(hours, minutes, 0, 0);
-  return out;
+  // dateOnly holds the intended calendar day in its UTC parts.
+  return easternWallClockToUtc(
+    dateOnly.getUTCFullYear(),
+    dateOnly.getUTCMonth(),
+    dateOnly.getUTCDate(),
+    hours,
+    minutes,
+  );
 }
 
 function formatICalDate(d: Date, allDay: boolean): string {


### PR DESCRIPTION
## Summary
Replaces the generic toast notification after volunteer signup with an enthusiastic, reassuring confirmation dialog that mirrors the SignUpGenius experience. The dialog displays event details and offers one-tap calendar integration (Google Calendar, Apple Calendar/Outlook).

## Key Changes

- **New `SignupSuccessDialog` component** (`volunteer-event-hub.tsx`): Celebratory confirmation shown immediately after successful signup, featuring:
  - Event recap (organization, date, time, location, roles)
  - Two calendar export buttons (Google Calendar deep link + .ics download)
  - Reassuring message about coordinator confirmation and email receipt
  - Branded styling with teal gradient and party popper icon

- **New calendar utilities module** (`client/src/lib/calendar-links.ts`): Client-side helpers that mirror server-side email logic:
  - `buildEventTimes()` — Parse event date + start/end times into UTC Date objects; treat missing start time as all-day event
  - `googleCalendarUrl()` — Generate Google Calendar "add event" deep link
  - `buildIcs()` — Generate RFC 5545 .ics file content for Apple Calendar / Outlook
  - `downloadIcs()` — Trigger browser download of .ics file
  - Consistent time parsing and formatting with existing email confirmation flow

- **Updated signup mutation handler**: Changed from toast notification to state-driven dialog:
  - The signed-up event is threaded through the mutation variables (not read from `selectedEvent` in `onSuccess`), so the confirmation always shows the correct event even if the user clicks a different event while the request is in flight
  - Stored in new `signupConfirmation` state

- **New state management**: Added `signupConfirmation` state to track event + roles for the confirmation dialog

- **Helper function**: `signupRoleLabel()` maps role keys (speaker, driver, general) to friendly display labels

## Implementation Details

- **Timezone handling**: Event start/end times are stored as Eastern (`America/New_York`) wall-clock strings (e.g. "10:00 AM" = 10am in Atlanta). They are converted to the correct UTC instant — DST-aware via `Intl`, so 10am Eastern becomes `14:00Z` during EDT / `15:00Z` during EST — so a 10am event lands on the volunteer's calendar as 10am, not shifted by the timezone offset. The event *day* is read from the date's UTC parts so it never drifts a day early. The same fix was applied to the server-side approval-email calendar links, which had the identical wall-clock-as-UTC bug.
- All-day event fallback when start time is missing; 2-hour default duration when only start time is present
- .ics generation includes proper escaping and iCalendar format compliance
- Dialog uses existing shadcn/ui components (Dialog, Button, Badge) and Sandwich Project brand colors
- Calendar export buttons styled to match the teal theme with hover states

https://claude.ai/code/session_01NmTLErDvid97k84JqVUwRx