### PR TITLE
Make weekly monitoring respect host status and exclude placeholder hosts

### DIFF
--- a/client/src/components/weekly-monitoring-dashboard.tsx
+++ b/client/src/components/weekly-monitoring-dashboard.tsx
@@ -1611,17 +1611,18 @@ export default function WeeklyMonitoringDashboard() {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
+            <p className="text-sm text-gray-600">
+              These are the active host locations tracked for weekly
+              submissions. A location is removed automatically when its host is
+              marked inactive in Host Management.
+            </p>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
-              {[
-                'East Cobb/Roswell',
-                'Dunwoody/PTC',
-                'Alpharetta',
-                'Sandy Springs',
-                'Intown/Druid Hills',
-                'Dacula',
-                'Flowery Branch',
-                'Collective Learning',
-              ].map((location) => (
+              {(Array.isArray(submissionStatus)
+                ? submissionStatus.map(
+                    (s: WeeklySubmissionStatus) => s.location
+                  )
+                : []
+              ).map((location: string) => (
                 <div
                   key={location}
                   className={`p-2 rounded-lg text-sm text-center ${
@@ -1658,9 +1659,6 @@ export default function WeeklyMonitoringDashboard() {
                 location.
               </p>
             </div>
-            <p className="text-sm text-gray-600">
-              Note: Dacula is marked as "maybe" - they may not submit every week
-            </p>
           </div>
         </CardContent>
       </Card>

--- a/server/routes/monitoring.ts
+++ b/server/routes/monitoring.ts
@@ -242,8 +242,9 @@ router.get('/multi-week-report/:weeks', async (req, res) => {
       endOfWeek.setDate(startOfWeek.getDate() + 6);
       endOfWeek.setHours(23, 59, 59, 999);
 
-      // Get submission status for this week
-      const submissionStatus = await checkWeeklySubmissions(i);
+      // Get submission status for this week (reuse expected locations to
+      // avoid a redundant hosts query per week)
+      const submissionStatus = await checkWeeklySubmissions(i, expectedLocations);
 
       // Update location stats
       submissionStatus.forEach((status: any) => {

--- a/server/routes/monitoring.ts
+++ b/server/routes/monitoring.ts
@@ -19,6 +19,20 @@ import { and, gte, lte, isNull, asc } from 'drizzle-orm';
 const router = Router();
 
 /**
+ * Placeholder/categorization host names that are NOT real weekly locations and
+ * should never appear in the submission grid. These are data-collection
+ * artifacts (e.g. historical group collections logged under a "Groups"
+ * pseudo-location). Compared lower-cased and trimmed.
+ */
+const NON_LOCATION_HOST_NAMES = new Set([
+  'groups',
+  'group',
+  'unassigned',
+  'unknown',
+  'unnamed groups',
+]);
+
+/**
  * Loosely match a collection's free-text hostName against a host location name.
  * Uses normalized equality first, then a guarded substring match (shorter side
  * must be >= 4 chars) to tolerate variations like "East Cobb" vs
@@ -315,6 +329,12 @@ router.get('/grid-report/:weeks', async (req, res) => {
       .filter((h: any) =>
         includeInactive ? true : (h.status ?? 'active') === 'active'
       )
+      // Exclude placeholder/categorization hosts that aren't real weekly
+      // locations (e.g. "Groups", "Unassigned", "Unknown") — these are data
+      // artifacts, not locations expected to submit a weekly log.
+      .filter((h: any) => !NON_LOCATION_HOST_NAMES.has(
+        String(h.name).toLowerCase().trim()
+      ))
       .sort((a: any, b: any) =>
         String(a.name).localeCompare(String(b.name))
       );

--- a/server/routes/monitoring.ts
+++ b/server/routes/monitoring.ts
@@ -7,7 +7,11 @@ import {
   validateSMSConfig,
 } from '../sms-service';
 import { logger } from '../utils/production-safe-logger';
-import { checkWeeklySubmissions, getWeekRange } from '../weekly-monitoring';
+import {
+  checkWeeklySubmissions,
+  getWeekRange,
+  getExpectedHostLocations,
+} from '../weekly-monitoring';
 import { db } from '../db';
 import { sandwichCollections } from '@shared/schema';
 import { and, gte, lte, isNull, asc } from 'drizzle-orm';
@@ -205,17 +209,8 @@ router.get('/multi-week-report/:weeks', async (req, res) => {
     const weekReports = [];
     const locationStats: { [location: string]: { submitted: number; missed: number } } = {};
 
-    // Get all expected locations
-    const expectedLocations = [
-      'East Cobb/Roswell',
-      'Dunwoody/PTC',
-      'Alpharetta',
-      'Sandy Springs',
-      'Intown/Druid Hills',
-      'Dacula',
-      'Flowery Branch',
-      'Collective Learning',
-    ];
+    // Get all expected locations (inactive/hidden hosts are excluded)
+    const expectedLocations = await getExpectedHostLocations();
 
     // Initialize stats for all locations
     expectedLocations.forEach((location) => {

--- a/server/weekly-monitoring.ts
+++ b/server/weekly-monitoring.ts
@@ -257,16 +257,19 @@ export async function getExpectedHostLocations(): Promise<string[]> {
       .select({ name: hosts.name, status: hosts.status })
       .from(hosts);
 
-    const inactiveHostNames = hostRecords
-      .filter((h) => h.status === 'inactive' || h.status === 'hidden')
-      .map((h) => h.name);
-
-    return EXPECTED_HOST_LOCATIONS.filter(
-      (location) =>
-        !inactiveHostNames.some((name) =>
-          locationMatchesHostName(location, name)
-        )
-    );
+    return EXPECTED_HOST_LOCATIONS.filter((location) => {
+      const matchingHosts = hostRecords.filter((h) =>
+        locationMatchesHostName(location, h.name)
+      );
+      // Fail-open: if no host record matches the curated name, keep it.
+      if (matchingHosts.length === 0) return true;
+      // Only drop the location when EVERY matching host is inactive/hidden.
+      // Host names aren't unique, so a stray duplicate inactive record must
+      // not hide a location that still has an active host.
+      return matchingHosts.some(
+        (h) => h.status !== 'inactive' && h.status !== 'hidden'
+      );
+    });
   } catch (error) {
     logger.error(
       'Failed to filter expected host locations by status; using full curated list',
@@ -279,9 +282,13 @@ export async function getExpectedHostLocations(): Promise<string[]> {
 /**
  * Check which host locations have submitted for a specific week
  * @param weeksAgo - Number of weeks to go back (0 = current week, 1 = last week, etc.)
+ * @param expectedLocationsArg - Optional precomputed expected-locations list.
+ *   Callers that loop over many weeks should fetch it once (via
+ *   getExpectedHostLocations) and pass it in to avoid a hosts query per week.
  */
 export async function checkWeeklySubmissions(
-  weeksAgo: number = 0
+  weeksAgo: number = 0,
+  expectedLocationsArg?: string[]
 ): Promise<WeeklySubmissionStatus[]> {
   const { startDate, endDate } = getWeekRange(weeksAgo);
 
@@ -329,8 +336,11 @@ export async function checkWeeklySubmissions(
       weeklySubmissions.map((sub) => sub.hostName?.toLowerCase().trim())
     );
 
-    // Check each expected location (inactive/hidden hosts are excluded)
-    const expectedLocations = await getExpectedHostLocations();
+    // Check each expected location (inactive/hidden hosts are excluded).
+    // Reuse the caller-provided list when present to avoid a redundant
+    // hosts query on every week in a multi-week loop.
+    const expectedLocations =
+      expectedLocationsArg ?? (await getExpectedHostLocations());
     const statusResults: WeeklySubmissionStatus[] = [];
 
     for (const expectedLocation of expectedLocations) {
@@ -399,10 +409,14 @@ export async function generateMultiWeekReport(
 ): Promise<ComprehensiveReport> {
   const weeks: MultiWeekReport[] = [];
 
+  // Fetch the status-filtered expected locations once and reuse it for every
+  // week (and the summary) to avoid a hosts query per week.
+  const locationsTracked = await getExpectedHostLocations();
+
   // Generate reports for each week
   for (let i = 0; i < numberOfWeeks; i++) {
     const { startDate, endDate } = getWeekRange(i);
-    const submissionStatus = await checkWeeklySubmissions(i);
+    const submissionStatus = await checkWeeklySubmissions(i, locationsTracked);
 
     weeks.push({
       weekRange: { startDate, endDate },
@@ -415,7 +429,6 @@ export async function generateMultiWeekReport(
   }
 
   // Calculate summary statistics (excluding inactive/hidden hosts)
-  const locationsTracked = await getExpectedHostLocations();
   const overallStats: {
     [location: string]: {
       submitted: number;

--- a/server/weekly-monitoring.ts
+++ b/server/weekly-monitoring.ts
@@ -224,6 +224,59 @@ function checkDunwoodyStatus(submissions: any[], location: string): any {
 }
 
 /**
+ * Loosely match a curated expected-location name against a host record name.
+ * Normalized equality first, then a guarded substring match (shorter side
+ * must be >= 4 chars) so "Dacula" matches "Dacula" without tiny names like
+ * "UGA" matching unrelated hosts.
+ */
+function locationMatchesHostName(location: string, hostName: string): boolean {
+  const a = (location || '').toLowerCase().trim();
+  const b = (hostName || '').toLowerCase().trim();
+  if (!a || !b) return false;
+  if (a === b) return true;
+  const sa = a.replace(/[\/\-\s]/g, '');
+  const sb = b.replace(/[\/\-\s]/g, '');
+  if (!sa || !sb) return false;
+  if (sa === sb) return true;
+  const [shorter, longer] = sa.length <= sb.length ? [sa, sb] : [sb, sa];
+  return shorter.length >= 4 && longer.includes(shorter);
+}
+
+/**
+ * The curated weekly host locations, with any location whose matching host
+ * record is explicitly marked inactive/hidden in Host Management removed.
+ * This lets coordinators retire a location (e.g. Dacula) simply by setting
+ * its host status to "inactive" — it then drops out of weekly monitoring,
+ * the multi-week report, and reminder emails automatically. A location is
+ * only removed when a host is *positively* known to be inactive, so unknown
+ * or unmatched locations are kept (fail-open).
+ */
+export async function getExpectedHostLocations(): Promise<string[]> {
+  try {
+    const hostRecords = await db
+      .select({ name: hosts.name, status: hosts.status })
+      .from(hosts);
+
+    const inactiveHostNames = hostRecords
+      .filter((h) => h.status === 'inactive' || h.status === 'hidden')
+      .map((h) => h.name);
+
+    return EXPECTED_HOST_LOCATIONS.filter(
+      (location) =>
+        !inactiveHostNames.some((name) =>
+          locationMatchesHostName(location, name)
+        )
+    );
+  } catch (error) {
+    logger.error(
+      'Failed to filter expected host locations by status; using full curated list',
+      error
+    );
+    return [...EXPECTED_HOST_LOCATIONS];
+  }
+}
+
+/**
  * Check which host locations have submitted for a specific week
  * @param weeksAgo - Number of weeks to go back (0 = current week, 1 = last week, etc.)
  */
@@ -276,10 +329,11 @@ export async function checkWeeklySubmissions(
       weeklySubmissions.map((sub) => sub.hostName?.toLowerCase().trim())
     );
 
-    // Check each expected location
+    // Check each expected location (inactive/hidden hosts are excluded)
+    const expectedLocations = await getExpectedHostLocations();
     const statusResults: WeeklySubmissionStatus[] = [];
 
-    for (const expectedLocation of EXPECTED_HOST_LOCATIONS) {
+    for (const expectedLocation of expectedLocations) {
       const normalizedExpected = expectedLocation.toLowerCase().trim();
 
       // Get submissions for this location
@@ -360,8 +414,8 @@ export async function generateMultiWeekReport(
     });
   }
 
-  // Calculate summary statistics
-  const locationsTracked = EXPECTED_HOST_LOCATIONS;
+  // Calculate summary statistics (excluding inactive/hidden hosts)
+  const locationsTracked = await getExpectedHostLocations();
   const overallStats: {
     [location: string]: {
       submitted: number;


### PR DESCRIPTION
## Summary

Follow-ups to the Submission Grid (#451) so weekly monitoring reflects real, active host locations.

## Changes

**Respect host active status in weekly monitoring** (`410c69f`)
- Weekly monitoring (Weekly Status tab, stats, multi-week report, and reminder emails) previously looped over a hardcoded `EXPECTED_HOST_LOCATIONS` list that ignored host status, so retired locations like Dacula kept showing up.
- Adds `getExpectedHostLocations()` which returns the curated list minus any location whose matching host record is explicitly marked **inactive/hidden** in Host Management. Fail-open: unmatched/unknown locations are kept.
- Marking a host inactive now drops it from monitoring everywhere automatically.
- The "Expected Weekly Locations" card reflects the status-filtered locations instead of a hardcoded list; the stale Dacula "maybe" note is removed.

**Exclude placeholder hosts from submission grid** (`93e6bce`)
- The grid lists all active hosts, which surfaced non-location placeholder/categorization records like "Groups" and "Unassigned".
- These are data-collection artifacts, not weekly locations, so they're filtered out of the grid by name (`Groups`, `Group`, `Unassigned`, `Unknown`, `Unnamed Groups`, case-insensitive).

## Notes
- Dacula drops off automatically as long as her host is set to **inactive** in Host Management.
- No changes to email/SMS sending logic beyond which locations are considered "expected".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeeQGGH7Sb6mcjY1CGCr4s)_