### PR TITLE
Filter volunteer hub events by designated volunteer need

### DIFF
--- a/server/routes/volunteer-event-hub.ts
+++ b/server/routes/volunteer-event-hub.ts
@@ -91,7 +91,9 @@ function dedupeVolunteerHubEvents(events: VolunteerHubEventRow[]): VolunteerHubE
  *
  * Note this gates on the *designated* need (count > 0), not unfilled slots, so
  * a fully-staffed event that did request help still appears (the existing
- * "fully staffed, extra help welcome" behavior is preserved for those).
+ * "fully staffed, extra help welcome" behavior is preserved for those). The van
+ * driver role only counts when it isn't a DHL-provided van — DHL handling the
+ * van/driver means there was never a volunteer van-driver role to begin with.
  */
 function eventOffersVolunteerOpportunity(event: VolunteerHubEventRow): boolean {
   if (event.selfTransport) return false;
@@ -99,7 +101,7 @@ function eventOffersVolunteerOpportunity(event: VolunteerHubEventRow): boolean {
     (event.driversNeeded ?? 0) > 0 ||
     (event.speakersNeeded ?? 0) > 0 ||
     (event.volunteersNeeded ?? 0) > 0 ||
-    !!event.vanDriverNeeded
+    (!!event.vanDriverNeeded && !event.isDhlVan)
   );
 }
 

--- a/server/routes/volunteer-event-hub.ts
+++ b/server/routes/volunteer-event-hub.ts
@@ -78,6 +78,31 @@ function dedupeVolunteerHubEvents(events: VolunteerHubEventRow[]): VolunteerHubE
   return Array.from(byId.values());
 }
 
+/**
+ * Whether an event is a genuine volunteer opportunity that belongs on the hub.
+ *
+ * Two kinds of events are auto-excluded even when a coordinator left
+ * `showOnVolunteerHub` on:
+ *   1. Self-transport events — the group handles its own logistics and isn't
+ *      looking for sign-ups at all.
+ *   2. Events with no role explicitly designated as needed — surfacing these
+ *      shows a misleading "extra help welcome" sign-up on events that never
+ *      asked for volunteers.
+ *
+ * Note this gates on the *designated* need (count > 0), not unfilled slots, so
+ * a fully-staffed event that did request help still appears (the existing
+ * "fully staffed, extra help welcome" behavior is preserved for those).
+ */
+function eventOffersVolunteerOpportunity(event: VolunteerHubEventRow): boolean {
+  if (event.selfTransport) return false;
+  return (
+    (event.driversNeeded ?? 0) > 0 ||
+    (event.speakersNeeded ?? 0) > 0 ||
+    (event.volunteersNeeded ?? 0) > 0 ||
+    !!event.vanDriverNeeded
+  );
+}
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -985,6 +1010,11 @@ router.get('/available-events', isAuthenticated, async (req: AuthenticatedReques
     //     whose date slipped into the past without being marked complete
     //     is stale data — don't surface it.
     const visibleEvents = events.filter(event => {
+      // Auto-exclude self-transport events and events with no designated
+      // volunteer need, regardless of the showOnVolunteerHub flag — these
+      // have nothing for a volunteer to sign up for.
+      if (!eventOffersVolunteerOpportunity(event)) return false;
+
       const eventDate = getEffectiveEventDate(event);
       if (!eventDate) return true;
       const eventDateObj = new Date(eventDate);


### PR DESCRIPTION
## Summary
Adds filtering logic to the volunteer event hub to auto-exclude events that don't offer genuine volunteer opportunities, even when coordinators have `showOnVolunteerHub` enabled. This prevents misleading "extra help welcome" signups on events that never requested volunteers.

## Changes
- **New function `eventOffersVolunteerOpportunity()`**: Determines whether an event has a legitimate volunteer opportunity by checking:
  - Excludes self-transport events (group handles its own logistics)
  - Requires at least one role explicitly designated as needed: drivers, speakers, volunteers, or van drivers
  - Checks the *designated* need (count > 0), not unfilled slots, so fully-staffed events that did request help still appear
  
- **Updated `/available-events` endpoint**: Applies the new filter before returning visible events to volunteers, ensuring only events with actual volunteer needs are surfaced

## Implementation Details
The filter is applied early in the visibility check, before date validation. This ensures self-transport and no-need events are consistently excluded regardless of the `showOnVolunteerHub` flag, while preserving the existing "fully staffed, extra help welcome" behavior for events that did explicitly request volunteers.

https://claude.ai/code/session_01LJYbXcSUPffZcp9YJVWs3c