### PR TITLE
fix(storage): add missing email-template-section delegators to storage wrapper

### DIFF
--- a/server/storage-wrapper.ts
+++ b/server/storage-wrapper.ts
@@ -10,6 +10,8 @@ import type {
   InsertAvailabilitySlot,
   EventRequest,
   InsertEventRequest,
+  InsertEmailTemplateSection,
+  UpdateEmailTemplateSection,
 } from '@shared/schema';
 
 class StorageWrapper implements IStorage {
@@ -2037,6 +2039,38 @@ class StorageWrapper implements IStorage {
       () => this.primaryStorage.updateDashboardDocumentOrder(updates),
       () => this.fallbackStorage.updateDashboardDocumentOrder(updates)
     );
+  }
+
+  // ==================== Email Template Sections ====================
+  // Delegated DIRECTLY to primary (database) storage — these are DB-backed
+  // admin customizations with no MemStorage implementation, so there is no
+  // meaningful in-memory fallback (executeWithFallback would just hit the same
+  // missing method). Errors propagate to the route, which handles the
+  // "table missing" case gracefully. Without these passthroughs the wrapper
+  // silently lacked the methods and `storage.getEmailTemplateSections is not a
+  // function` was thrown at runtime, 500ing the email composer's section fetch.
+  async getEmailTemplateSections(templateType?: string) {
+    return this.primaryStorage.getEmailTemplateSections(templateType);
+  }
+
+  async getEmailTemplateSection(templateType: string, sectionKey: string) {
+    return this.primaryStorage.getEmailTemplateSection(templateType, sectionKey);
+  }
+
+  async getEmailTemplateSectionById(id: number) {
+    return this.primaryStorage.getEmailTemplateSectionById(id);
+  }
+
+  async createEmailTemplateSection(data: InsertEmailTemplateSection) {
+    return this.primaryStorage.createEmailTemplateSection(data);
+  }
+
+  async updateEmailTemplateSection(id: number, data: UpdateEmailTemplateSection) {
+    return this.primaryStorage.updateEmailTemplateSection(id, data);
+  }
+
+  async resetEmailTemplateSectionToDefault(id: number) {
+    return this.primaryStorage.resetEmailTemplateSectionToDefault(id);
   }
 
   // Event Collaboration Comments


### PR DESCRIPTION
## What
Adds the six `emailTemplateSection*` methods to `StorageWrapper` (the exported `storage`), delegating directly to the database storage layer.

## Why
`GET /api/email-templates/sections` was returning **500** every time the event email composer opened, with this server-side error:

```
TypeError: storage.getEmailTemplateSections is not a function
```

The exported `storage` is `StorageWrapper`, which `implements IStorage` but never actually defined any of the email-template-section methods. The methods exist on `DatabaseStorage`, but the wrapper in front of it had no passthrough — so the call was `undefined` at runtime. It only compiled because the project ships despite pre-existing TypeScript errors, so the gap surfaced only in production.

## Changes
- `server/storage-wrapper.ts`: add `getEmailTemplateSections`, `getEmailTemplateSection`, `getEmailTemplateSectionById`, `createEmailTemplateSection`, `updateEmailTemplateSection`, `resetEmailTemplateSectionToDefault`, delegating **directly** to primary (database) storage.
  - No `MemStorage` fallback: `MemStorage` doesn't implement these DB-backed admin customizations, so the fallback path would just re-throw the same missing-method error. Errors instead propagate to the route, which already degrades gracefully when the table is missing (returns `[]` for Postgres `undefined_table`, 500 otherwise).
- Import the two additional schema types used by the write signatures.

## Scope / note
This fixes the **section-fetch 500** only. The separate `POST /api/emails/event` send failure is a **SendGrid-side rejection** (`SendGrid returned false`, `field: null`) and does **not** call this method — the send handler builds its email from hardcoded defaults and never touches template sections. That one is being tracked separately and needs the actual SendGrid rejection reason to resolve.

## Testing
- `tsc --noEmit` clean for `server/storage-wrapper.ts`.
- Follows the existing wrapper delegation conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdrwongSVEcKXArY1pmARv)_