### PR TITLE
Daily error digest (replace per-error admin emails) + storage retry hardening

### DIFF
--- a/server/services/application-error-logger.ts
+++ b/server/services/application-error-logger.ts
@@ -1,6 +1,6 @@
 import { db } from '../db';
 import { applicationErrorLogs } from '@shared/schema';
-import { and, eq, gte } from 'drizzle-orm';
+import { and, eq, gte, inArray, desc } from 'drizzle-orm';
 import { logger } from '../utils/production-safe-logger';
 import { appendErrorLogToSheet } from '../services/error-log-sheet-sync';
 
@@ -115,6 +115,144 @@ async function sendAdminNotification(
 }
 
 /**
+ * Collapse a message into a stable fingerprint by stripping the parts that
+ * vary between otherwise-identical errors (ids, uuids, timestamps, quoted
+ * values), so repeats of the same failure group together in the digest.
+ */
+function normalizeMessage(message: string): string {
+  return message
+    .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, '<uuid>')
+    .replace(/\b\d[\d.,:-]*\b/g, '#')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 200);
+}
+
+interface ErrorDigestGroup {
+  source: string;
+  category: string | null;
+  severity: string;
+  sample: string;
+  count: number;
+  last: Date;
+}
+
+/**
+ * Roll up the last 24h of error/critical logs into ONE grouped summary email
+ * to the admin. Runs from a daily cron. Sends nothing when there were no errors
+ * (no "all clear" noise). All errors remain in the DB table + Google Sheet
+ * regardless — this is purely the notification channel.
+ */
+export async function sendDailyErrorDigest(): Promise<{
+  sent: boolean;
+  total: number;
+  groups: number;
+}> {
+  const since = new Date();
+  since.setHours(since.getHours() - 24);
+
+  const rows = await db
+    .select({
+      source: applicationErrorLogs.source,
+      severity: applicationErrorLogs.severity,
+      category: applicationErrorLogs.category,
+      message: applicationErrorLogs.message,
+      createdAt: applicationErrorLogs.createdAt,
+    })
+    .from(applicationErrorLogs)
+    .where(
+      and(
+        gte(applicationErrorLogs.createdAt, since),
+        inArray(applicationErrorLogs.severity, ['error', 'critical'])
+      )
+    )
+    .orderBy(desc(applicationErrorLogs.createdAt));
+
+  if (rows.length === 0) {
+    logger.log('[ApplicationErrorLogger] Daily digest: no errors in the last 24h, skipping email');
+    return { sent: false, total: 0, groups: 0 };
+  }
+
+  const groups = new Map<string, ErrorDigestGroup>();
+  for (const r of rows) {
+    const key = `${r.source}|${r.category || ''}|${normalizeMessage(r.message)}`;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.count += 1;
+      if (r.createdAt > existing.last) existing.last = r.createdAt;
+      if (r.severity === 'critical') existing.severity = 'critical';
+    } else {
+      groups.set(key, {
+        source: r.source,
+        category: r.category ?? null,
+        severity: r.severity,
+        sample: r.message,
+        count: 1,
+        last: r.createdAt,
+      });
+    }
+  }
+
+  const sorted = [...groups.values()].sort((a, b) => b.count - a.count);
+  const criticalCount = rows.filter((r) => r.severity === 'critical').length;
+
+  const textLines = sorted.map(
+    (g) =>
+      `• [${g.severity}] ${g.source}/${g.category || 'general'} ×${g.count} — ${g.sample.slice(0, 140)} (last: ${g.last.toISOString()})`
+  );
+  const htmlRows = sorted
+    .map(
+      (g) => `
+        <tr>
+          <td style="padding:6px 10px;border-bottom:1px solid #eee;">${g.severity === 'critical' ? '🔴' : '🟠'} ${g.severity}</td>
+          <td style="padding:6px 10px;border-bottom:1px solid #eee;">${g.source}/${g.category || 'general'}</td>
+          <td style="padding:6px 10px;border-bottom:1px solid #eee;text-align:right;font-weight:bold;">${g.count}</td>
+          <td style="padding:6px 10px;border-bottom:1px solid #eee;">${g.sample.slice(0, 160).replace(/</g, '&lt;')}</td>
+        </tr>`
+    )
+    .join('');
+
+  try {
+    const { sendEmail } = await import('../sendgrid');
+    await sendEmail({
+      to: ADMIN_EMAIL,
+      from: 'noreply@thesandwichproject.org',
+      subject: `[TSP App] Daily error digest — ${rows.length} errors, ${sorted.length} types${criticalCount ? `, ${criticalCount} critical` : ''}`,
+      text: [
+        `Errors in the last 24 hours: ${rows.length} (${sorted.length} distinct types${criticalCount ? `, ${criticalCount} critical` : ''}).`,
+        `Critical errors were also emailed individually when they occurred.`,
+        `Full detail lives in the admin error log and the error-log Google Sheet.`,
+        '',
+        ...textLines,
+      ].join('\n'),
+      html: `
+        <div style="font-family: Arial, sans-serif; max-width: 720px;">
+          <h2 style="color:#236383;">Daily Error Digest</h2>
+          <p><strong>${rows.length}</strong> errors in the last 24 hours across <strong>${sorted.length}</strong> distinct types${criticalCount ? `, including <strong>${criticalCount}</strong> critical` : ''}.</p>
+          <p style="color:#666;font-size:13px;">Critical errors were also emailed individually as they happened. Full detail is in the admin error log and the error-log Google Sheet.</p>
+          <table style="border-collapse:collapse;width:100%;font-size:14px;">
+            <thead>
+              <tr style="background:#f4f4f4;text-align:left;">
+                <th style="padding:6px 10px;">Severity</th>
+                <th style="padding:6px 10px;">Source</th>
+                <th style="padding:6px 10px;text-align:right;">Count</th>
+                <th style="padding:6px 10px;">Example message</th>
+              </tr>
+            </thead>
+            <tbody>${htmlRows}</tbody>
+          </table>
+        </div>
+      `,
+    });
+    logger.log(`[ApplicationErrorLogger] Daily digest sent: ${rows.length} errors, ${sorted.length} groups`);
+    return { sent: true, total: rows.length, groups: sorted.length };
+  } catch (err) {
+    logger.error('[ApplicationErrorLogger] Failed to send daily error digest:', err);
+    return { sent: false, total: rows.length, groups: sorted.length };
+  }
+}
+
+/**
  * Persist a server-side error for the admin error log. Fire-and-forget — never throws.
  */
 export function logApplicationError(input: ApplicationErrorInput): void {
@@ -141,9 +279,12 @@ export function logApplicationError(input: ApplicationErrorInput): void {
         })
         .returning({ id: applicationErrorLogs.id });
 
+      // Only CRITICAL errors page the admin immediately. Everything at 'error'
+      // severity is captured in the DB (+ Google Sheet) and rolled up into the
+      // once-daily digest email (see sendDailyErrorDigest) so a high-traffic day
+      // produces one summary instead of a flood of per-error messages.
       const shouldNotify =
-        input.notifyAdmin !== false &&
-        (severity === 'error' || severity === 'critical');
+        input.notifyAdmin !== false && severity === 'critical';
 
       if (shouldNotify && row?.id) {
         const canEmail = await shouldSendAdminEmail(input);

--- a/server/services/application-error-logger.ts
+++ b/server/services/application-error-logger.ts
@@ -213,8 +213,8 @@ export async function sendDailyErrorDigest(): Promise<{
     .join('');
 
   try {
-    const { sendEmail } = await import('../sendgrid');
-    await sendEmail({
+    const { sendEmailWithResult } = await import('../sendgrid');
+    const sendResult = await sendEmailWithResult({
       to: ADMIN_EMAIL,
       from: 'noreply@thesandwichproject.org',
       subject: `[TSP App] Daily error digest — ${rows.length} errors, ${sorted.length} types${criticalCount ? `, ${criticalCount} critical` : ''}`,
@@ -244,6 +244,15 @@ export async function sendDailyErrorDigest(): Promise<{
         </div>
       `,
     });
+    // sendEmail resolves false (not throws) on a missing key or SendGrid
+    // rejection, so check the result explicitly — otherwise a failed delivery
+    // would be recorded as a successful digest and that 24h window lost.
+    if (!sendResult.success) {
+      logger.error(
+        `[ApplicationErrorLogger] Daily digest email failed: ${sendResult.error || 'unknown'}`
+      );
+      return { sent: false, total: rows.length, groups: sorted.length };
+    }
     logger.log(`[ApplicationErrorLogger] Daily digest sent: ${rows.length} errors, ${sorted.length} groups`);
     return { sent: true, total: rows.length, groups: sorted.length };
   } catch (err) {

--- a/server/services/application-error-logger.ts
+++ b/server/services/application-error-logger.ts
@@ -3,6 +3,7 @@ import { applicationErrorLogs } from '@shared/schema';
 import { and, eq, gte, inArray, desc } from 'drizzle-orm';
 import { logger } from '../utils/production-safe-logger';
 import { appendErrorLogToSheet } from '../services/error-log-sheet-sync';
+import { FROM_EMAIL } from '../config/organization';
 
 export type ApplicationErrorSource =
   | 'sms_parser'
@@ -72,7 +73,7 @@ async function sendAdminNotification(
 
     await sendEmail({
       to: ADMIN_EMAIL,
-      from: 'noreply@thesandwichproject.org',
+      from: FROM_EMAIL,
       subject: `[TSP App ${severity.toUpperCase()}] ${input.source}: ${input.message.slice(0, 80)}`,
       text: [
         `Source: ${input.source}`,
@@ -128,6 +129,16 @@ function normalizeMessage(message: string): string {
     .slice(0, 200);
 }
 
+/** Escape user-influenced text before interpolating into the digest email HTML. */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 interface ErrorDigestGroup {
   source: string;
   category: string | null;
@@ -148,8 +159,9 @@ export async function sendDailyErrorDigest(): Promise<{
   total: number;
   groups: number;
 }> {
-  const since = new Date();
-  since.setHours(since.getHours() - 24);
+  // Millisecond offset keeps the window exactly 24h regardless of DST shifts
+  // (setHours(getHours()-24) would be 23h/25h across a transition).
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
 
   const rows = await db
     .select({
@@ -193,7 +205,10 @@ export async function sendDailyErrorDigest(): Promise<{
     }
   }
 
-  const sorted = [...groups.values()].sort((a, b) => b.count - a.count);
+  // Most frequent first (best for triage), ties broken by most recent.
+  const sorted = [...groups.values()].sort(
+    (a, b) => b.count - a.count || b.last.getTime() - a.last.getTime()
+  );
   const criticalCount = rows.filter((r) => r.severity === 'critical').length;
 
   const textLines = sorted.map(
@@ -201,22 +216,26 @@ export async function sendDailyErrorDigest(): Promise<{
       `• [${g.severity}] ${g.source}/${g.category || 'general'} ×${g.count} — ${g.sample.slice(0, 140)} (last: ${g.last.toISOString()})`
   );
   const htmlRows = sorted
-    .map(
-      (g) => `
+    .map((g) => {
+      // Error messages are user-influenced — escape every interpolated field.
+      const severity = escapeHtml(g.severity);
+      const sourceLabel = escapeHtml(`${g.source}/${g.category || 'general'}`);
+      const sample = escapeHtml(g.sample.slice(0, 160));
+      return `
         <tr>
-          <td style="padding:6px 10px;border-bottom:1px solid #eee;">${g.severity === 'critical' ? '🔴' : '🟠'} ${g.severity}</td>
-          <td style="padding:6px 10px;border-bottom:1px solid #eee;">${g.source}/${g.category || 'general'}</td>
+          <td style="padding:6px 10px;border-bottom:1px solid #eee;">${g.severity === 'critical' ? '🔴' : '🟠'} ${severity}</td>
+          <td style="padding:6px 10px;border-bottom:1px solid #eee;">${sourceLabel}</td>
           <td style="padding:6px 10px;border-bottom:1px solid #eee;text-align:right;font-weight:bold;">${g.count}</td>
-          <td style="padding:6px 10px;border-bottom:1px solid #eee;">${g.sample.slice(0, 160).replace(/</g, '&lt;')}</td>
-        </tr>`
-    )
+          <td style="padding:6px 10px;border-bottom:1px solid #eee;">${sample}</td>
+        </tr>`;
+    })
     .join('');
 
   try {
     const { sendEmailWithResult } = await import('../sendgrid');
     const sendResult = await sendEmailWithResult({
       to: ADMIN_EMAIL,
-      from: 'noreply@thesandwichproject.org',
+      from: FROM_EMAIL,
       subject: `[TSP App] Daily error digest — ${rows.length} errors, ${sorted.length} types${criticalCount ? `, ${criticalCount} critical` : ''}`,
       text: [
         `Errors in the last 24 hours: ${rows.length} (${sorted.length} distinct types${criticalCount ? `, ${criticalCount} critical` : ''}).`,

--- a/server/services/cron-jobs.ts
+++ b/server/services/cron-jobs.ts
@@ -20,6 +20,7 @@ import { isNotificationSuppressed } from '../utils/notification-suppression';
 import { processAdminWeeklyDigest, processAdminWeeklySms } from './admin-weekly-digest-service';
 import { processPredictionAlerts } from './prediction-alert-service';
 import { processCheckInReminders } from './check-in-reminder-service';
+import { sendDailyErrorDigest } from './application-error-logger';
 import { ALERT_TYPES } from '@shared/alert-catalog';
 import { getEffectivePrefs } from './notifications/preferences';
 import { getEffectiveEventDate } from '../../shared/event-validation-utils';
@@ -1552,6 +1553,41 @@ export function initializeCronJobs() {
     timezone: 'America/New_York',
   });
 
+  // Daily error digest — one grouped summary of the last 24h of error/critical
+  // logs at 7:05 AM ET. Critical errors are still paged immediately when they
+  // occur; this rolls up the rest so a busy day is one email, not a flood.
+  const errorDigestJob = cron.schedule('5 7 * * *', async () => {
+    if (!isProduction) {
+      cronLogger.info('Skipping daily error digest - not production environment');
+      return;
+    }
+    cronLogger.info('Running daily error digest...');
+    try {
+      const result = await sendDailyErrorDigest();
+      cronLogger.info('Daily error digest completed', {
+        sent: result.sent,
+        total: result.total,
+        groups: result.groups,
+        timestamp: new Date(),
+      });
+    } catch (error) {
+      logError(
+        error as Error,
+        'Error running daily error digest cron job',
+        undefined,
+        { jobType: 'error-digest' }
+      );
+    }
+  }, {
+    scheduled: true,
+    timezone: 'America/New_York',
+  });
+
+  cronLogger.info('Daily error digest job scheduled successfully', {
+    schedule: 'Daily at 7:05 AM',
+    timezone: 'America/New_York',
+  });
+
   // Return job references in case we need to manage them later
   return {
     hostScraperJob,
@@ -1571,6 +1607,7 @@ export function initializeCronJobs() {
     predictionAlertJob,
     checkInReminderJob,
     integrationHealthJob,
+    errorDigestJob,
   };
 }
 
@@ -1596,5 +1633,6 @@ export function stopAllCronJobs(jobs: ReturnType<typeof initializeCronJobs>) {
   jobs.predictionAlertJob.stop();
   jobs.checkInReminderJob.stop();
   jobs.integrationHealthJob.stop();
+  jobs.errorDigestJob.stop();
   cronLogger.info('All cron jobs stopped successfully');
 }

--- a/server/storage-wrapper.ts
+++ b/server/storage-wrapper.ts
@@ -81,6 +81,53 @@ class StorageWrapper implements IStorage {
    * MemStorage writes are lost on restart. Instead we throw the error so
    * the API route can return a proper error to the client.
    */
+  /** Transient DB errors worth retrying (Neon cold start, brief connection hiccups). */
+  private isTransientError(error: any): boolean {
+    return error?.message?.includes('connection') ||
+      error?.message?.includes('timeout') ||
+      error?.message?.includes('ECONNREFUSED') ||
+      error?.message?.includes('ECONNRESET') ||
+      error?.message?.includes('socket hang up') ||
+      error?.message?.includes('fetch failed') ||
+      error?.code === 'ETIMEDOUT' ||
+      error?.code === 'ECONNRESET' ||
+      // PostgreSQL transient error codes
+      error?.code === '40001' || // serialization_failure
+      error?.code === '40P01' || // deadlock_detected
+      error?.code === '08006' || // connection_failure
+      error?.code === '08001' || // sqlclient_unable_to_establish_sqlconnection
+      error?.code === '57P01';   // admin_shutdown (Neon cold start)
+  }
+
+  /**
+   * Retry a PRIMARY-storage operation on transient errors with the same
+   * backoff as executeWithFallback, but WITHOUT a MemStorage fallback. Use for
+   * operations MemStorage can't serve (falling back would just throw) and where
+   * a valid `undefined` result (not-found) must NOT be treated as a fallback
+   * trigger. Non-transient errors and exhausted retries re-throw so the route
+   * can handle them.
+   */
+  private async executePrimaryWithRetry<T>(operation: () => Promise<T>): Promise<T> {
+    const maxRetries = 2;
+    let lastError: any = null;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await operation();
+      } catch (error: any) {
+        lastError = error;
+        if (!this.isTransientError(error) || attempt === maxRetries) {
+          break;
+        }
+        const delay = Math.min(200 * Math.pow(2, attempt), 2000);
+        logger.warn(`Primary storage operation failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms:`, error?.message);
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+    }
+
+    throw lastError;
+  }
+
   private async executeWithFallback<T>(
     operation: () => Promise<T>,
     fallbackOperation: () => Promise<T>,
@@ -106,20 +153,7 @@ class StorageWrapper implements IStorage {
       } catch (error: any) {
         lastError = error;
         // Don't retry non-transient errors (validation, not-found, etc.)
-        const isTransient = error?.message?.includes('connection') ||
-          error?.message?.includes('timeout') ||
-          error?.message?.includes('ECONNREFUSED') ||
-          error?.message?.includes('ECONNRESET') ||
-          error?.message?.includes('socket hang up') ||
-          error?.message?.includes('fetch failed') ||
-          error?.code === 'ETIMEDOUT' ||
-          error?.code === 'ECONNRESET' ||
-          // PostgreSQL transient error codes
-          error?.code === '40001' || // serialization_failure
-          error?.code === '40P01' || // deadlock_detected
-          error?.code === '08006' || // connection_failure
-          error?.code === '08001' || // sqlclient_unable_to_establish_sqlconnection
-          error?.code === '57P01';   // admin_shutdown (Neon cold start)
+        const isTransient = this.isTransientError(error);
 
         if (!isTransient || attempt === maxRetries) {
           break; // Don't retry non-transient errors or if we've exhausted retries
@@ -2042,35 +2076,50 @@ class StorageWrapper implements IStorage {
   }
 
   // ==================== Email Template Sections ====================
-  // Delegated DIRECTLY to primary (database) storage — these are DB-backed
-  // admin customizations with no MemStorage implementation, so there is no
-  // meaningful in-memory fallback (executeWithFallback would just hit the same
-  // missing method). Errors propagate to the route, which handles the
-  // "table missing" case gracefully. Without these passthroughs the wrapper
-  // silently lacked the methods and `storage.getEmailTemplateSections is not a
-  // function` was thrown at runtime, 500ing the email composer's section fetch.
+  // Delegated to primary (database) storage via executePrimaryWithRetry —
+  // these are DB-backed admin customizations with no MemStorage implementation,
+  // so there is no meaningful in-memory fallback (executeWithFallback would just
+  // hit the same missing method, and would also treat a valid `undefined`
+  // not-found as a fallback trigger). The retry-only helper still recovers from
+  // transient DB errors (Neon cold starts) without those hazards. Errors
+  // propagate to the route, which handles the "table missing" case gracefully.
+  // Without these passthroughs the wrapper silently lacked the methods and
+  // `storage.getEmailTemplateSections is not a function` was thrown at runtime,
+  // 500ing the email composer's section fetch.
   async getEmailTemplateSections(templateType?: string) {
-    return this.primaryStorage.getEmailTemplateSections(templateType);
+    return this.executePrimaryWithRetry(() =>
+      this.primaryStorage.getEmailTemplateSections(templateType)
+    );
   }
 
   async getEmailTemplateSection(templateType: string, sectionKey: string) {
-    return this.primaryStorage.getEmailTemplateSection(templateType, sectionKey);
+    return this.executePrimaryWithRetry(() =>
+      this.primaryStorage.getEmailTemplateSection(templateType, sectionKey)
+    );
   }
 
   async getEmailTemplateSectionById(id: number) {
-    return this.primaryStorage.getEmailTemplateSectionById(id);
+    return this.executePrimaryWithRetry(() =>
+      this.primaryStorage.getEmailTemplateSectionById(id)
+    );
   }
 
   async createEmailTemplateSection(data: InsertEmailTemplateSection) {
-    return this.primaryStorage.createEmailTemplateSection(data);
+    return this.executePrimaryWithRetry(() =>
+      this.primaryStorage.createEmailTemplateSection(data)
+    );
   }
 
   async updateEmailTemplateSection(id: number, data: UpdateEmailTemplateSection) {
-    return this.primaryStorage.updateEmailTemplateSection(id, data);
+    return this.executePrimaryWithRetry(() =>
+      this.primaryStorage.updateEmailTemplateSection(id, data)
+    );
   }
 
   async resetEmailTemplateSectionToDefault(id: number) {
-    return this.primaryStorage.resetEmailTemplateSectionToDefault(id);
+    return this.executePrimaryWithRetry(() =>
+      this.primaryStorage.resetEmailTemplateSectionToDefault(id)
+    );
   }
 
   // Event Collaboration Comments

--- a/server/storage-wrapper.ts
+++ b/server/storage-wrapper.ts
@@ -120,7 +120,9 @@ class StorageWrapper implements IStorage {
           break;
         }
         const delay = Math.min(200 * Math.pow(2, attempt), 2000);
-        logger.warn(`Primary storage operation failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms:`, error?.message);
+        // Log the full error object (not just .message) so Winston preserves
+        // the stack/structured context for diagnosing repeated transient failures.
+        logger.warn(`Primary storage operation failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms:`, error);
         await new Promise(resolve => setTimeout(resolve, delay));
       }
     }


### PR DESCRIPTION
Two independent follow-ups, plus review fixes.

## 1. Daily error digest instead of per-error admin emails
High email volume surfaced how noisy the per-error admin alerts are: every `error`-severity log emailed `katie@`, deduped only by an exact `source + message + category` match within 6h — so any error with a varying message (ids, paths, SendGrid reasons) re-emailed and flooded the inbox.

- **Only `critical` severity now pages the admin immediately.**
- New `sendDailyErrorDigest()` rolls up the **last 24h** of `error`/`critical` logs into **one** grouped summary email (normalized fingerprint → counts, **most frequent first**, ties broken by most recent) and **sends nothing on a clean day**.
- Scheduled daily at **7:05 AM ET** in `cron-jobs.ts`.
- All errors still land in the `application_error_logs` table **and** the error-log Google Sheet — this only changes the *notification channel*, nothing is lost.

## 2. Retry hardening on the email-template-section wrapper methods (addresses Copilot review on #465)
The six `emailTemplateSection*` methods delegated straight to `primaryStorage`, so unlike every other wrapper method they skipped transient-error retry/backoff (Neon cold starts, brief connection blips) and could spuriously 500.

- Add `executePrimaryWithRetry()`: same transient detection + backoff as `executeWithFallback`, but with **no MemStorage fallback** (MemStorage doesn't implement these) and **no "undefined result triggers fallback"** behavior (a valid not-found `undefined` must pass through).
- Extract the shared transient check into `isTransientError()` and route the six methods through the retry helper.

## Review fixes (Codex + Copilot)
- Digest treats a failed send (`sendEmailWithResult().success === false`) as a failure instead of falsely reporting success.
- HTML-escape all user-influenced fields in the digest email (source/category/severity/sample).
- DST-safe 24h window via millisecond offset.
- Digest + immediate critical alert now send from the configured verified sender (`FROM_EMAIL`) rather than a hardcoded `noreply@`.
- Retry warning logs the full error object (stack preserved under Winston).

## Testing
- `tsc --noEmit` clean for `storage-wrapper.ts`, `application-error-logger.ts`, `cron-jobs.ts`.
- Digest skips entirely when there are no errors in the window.

## Not included
This does **not** touch the live `SENDGRID_API_KEY` problem (the actual toolkit-send failure) — that was a stale Replit secret in the running deployment, resolved outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)