### PR TITLE
Add Postgres error classification for actionable API responses

### DIFF
--- a/client/src/components/event-requests/EventSchedulingForm.tsx
+++ b/client/src/components/event-requests/EventSchedulingForm.tsx
@@ -782,6 +782,20 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
       const isNetworkError = error?.message?.includes('Failed to fetch') || error?.message?.includes('Request timeout');
       const orgName = eventRequest?.organizationName || formData.organizationName || 'this event';
 
+      // Capture the server's structured DB detail (see server pg-error-utils) so
+      // the auto-filed error report pinpoints the real cause — the raw DB
+      // message / SQLSTATE code / column — instead of just "Save Failed".
+      const dbDetail = [
+        error?.data?.dbError,
+        error?.data?.dbCode ? `code=${error.data.dbCode}` : null,
+        error?.data?.dbColumn || error?.data?.column
+          ? `column=${error.data.dbColumn || error.data.column}`
+          : null,
+        error?.status ? `http=${error.status}` : null,
+      ]
+        .filter(Boolean)
+        .join(' | ');
+
       let errorTitle = 'Save Failed';
       let errorDescription = mode === 'edit' ? 'Failed to update event.' : 'Failed to schedule event.';
 
@@ -806,6 +820,10 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
         duration: 10000,
         report: {
           whatDoing: mode === 'edit' ? 'Save event edits in scheduling form' : 'Schedule an event in the scheduling form',
+          expectedOutcome: 'The event request should save successfully.',
+          actualOutcome: dbDetail
+            ? `${errorTitle}: ${errorDescription} [${dbDetail}]`
+            : `${errorTitle}: ${errorDescription}`,
           ...(eventRequest?.id
             ? {
                 recordType: 'event_request',

--- a/server/routes/event-requests-legacy.ts
+++ b/server/routes/event-requests-legacy.ts
@@ -3077,22 +3077,23 @@ router.patch(
           message: classified.message,
           error: classified.error,
           column: classified.column,
-          // Same structured DB detail on both the 4xx and 500 paths so the
-          // client's error report captures the raw message, SQLSTATE code, and
-          // column consistently. None of these are shown to the user (the
-          // client renders `message`).
-          dbError: pg.message,
+          // Stable, non-sensitive diagnostics on both the 4xx and 500 paths so
+          // the client's error report can identify the field/error class. The
+          // raw DB message can name internal schema/constraints, so it's gated
+          // to development (same convention as `details` below); the full
+          // message is always written to the server logs regardless of env.
           dbCode: pg.code,
           dbColumn: pg.column,
+          dbError: process.env.NODE_ENV === 'development' ? pg.message : undefined,
         });
       }
 
       res.status(500).json({
         message: 'Failed to update event request',
         error: err?.message || 'Unknown error',
-        dbError: pg.message,
         dbCode: pg.code,
         dbColumn: pg.column,
+        dbError: process.env.NODE_ENV === 'development' ? pg.message : undefined,
         details: process.env.NODE_ENV === 'development' ? err?.stack : undefined
       });
     }

--- a/server/routes/event-requests-legacy.ts
+++ b/server/routes/event-requests-legacy.ts
@@ -28,6 +28,7 @@ import { logger } from '../middleware/logger';
 import type { AuthenticatedRequest } from '../types/express';
 import { emitEventRequestUpdate } from '../socket-chat';
 import { safeJsonParse } from '../utils/safe-json';
+import { getUndefinedColumn, dropColumnKey, classifyDbError, parsePgError } from '../utils/pg-error-utils';
 import { geocodeAddress } from '../utils/geocoding';
 import { rateLimiter } from '../utils/rate-limiter';
 import { getEffectiveEventDate, getAssignmentUrgentGaps, daysSinceSubmitted, daysUntilEventDate } from '../../shared/event-validation-utils';
@@ -2899,24 +2900,42 @@ router.patch(
       }
 
       let updatedEventRequest;
-      try {
-        updatedEventRequest = await storage.updateEventRequest(id, {
-          ...processedUpdates,
-          updatedAt: new Date(),
-        });
-      } catch (updateError: any) {
-        // If the update fails and includes addedToOfficialSheetAt, retry without it
-        // (the column may not exist yet if migration 0043 hasn't run)
-        if (processedUpdates.addedToOfficialSheetAt !== undefined) {
-          logger.warn(`[PATCH /:id] Update failed with addedToOfficialSheetAt, retrying without it: ${updateError?.message}`);
-          droppedFields.push({ field: 'addedToOfficialSheetAt', reason: 'Database column not available on this branch (migration pending)' });
-          const { addedToOfficialSheetAt, ...updatesWithoutTimestamp } = processedUpdates;
-          updatedEventRequest = await storage.updateEventRequest(id, {
-            ...updatesWithoutTimestamp,
-            updatedAt: new Date(),
-          });
-        } else {
-          throw updateError;
+      {
+        // Some columns exist in the Drizzle schema but not on the current
+        // database branch — migrations are applied manually per Neon branch, so
+        // dev and production drift. Writing such a column throws Postgres 42703
+        // (undefined_column) and used to fail the ENTIRE save with an opaque
+        // 500 (the old code only special-cased addedToOfficialSheetAt). Instead,
+        // detect the missing column, drop it, record it for the client's
+        // partial-save warning, and retry. The loop handles several missing
+        // columns in a row; the bound prevents an infinite loop if a drop never
+        // resolves the error.
+        const attemptUpdates: Record<string, any> = { ...processedUpdates };
+        const MAX_COLUMN_DROP_RETRIES = 12;
+        for (let attempt = 0; ; attempt++) {
+          try {
+            updatedEventRequest = await storage.updateEventRequest(id, {
+              ...attemptUpdates,
+              updatedAt: new Date(),
+            });
+            break;
+          } catch (updateError: any) {
+            const missingColumn = getUndefinedColumn(updateError);
+            const droppedKey = missingColumn
+              ? dropColumnKey(attemptUpdates, missingColumn)
+              : null;
+            if (droppedKey && attempt < MAX_COLUMN_DROP_RETRIES) {
+              logger.warn(
+                `[PATCH /:id] Column "${missingColumn}" is not on this DB branch; dropping "${droppedKey}" and retrying: ${updateError?.message}`
+              );
+              droppedFields.push({
+                field: droppedKey,
+                reason: 'Database column not available on this branch (migration pending)',
+              });
+              continue;
+            }
+            throw updateError;
+          }
         }
       }
 
@@ -3035,21 +3054,35 @@ router.patch(
       res.json(responsePayload);
     } catch (error: unknown) {
       const err = error as Error;
+      const pg = parsePgError(error);
       logger.error('Error updating event request:', error);
       logger.error('Error stack:', err?.stack);
+      // Log the structured DB detail so the real cause (column/constraint/code)
+      // is recoverable from server logs even when the client only sees a
+      // friendly message.
+      logger.error(
+        `[PATCH /:id] DB error detail — code=${pg.code ?? 'n/a'}, column=${pg.column ?? 'n/a'}, constraint=${pg.constraint ?? 'n/a'}`
+      );
 
-      // Check for specific database errors
-      if (err?.message?.includes('invalid input syntax')) {
-        return res.status(400).json({
-          message: 'Invalid data format',
-          error: err.message,
-          details: 'Please check that all fields contain valid data'
+      // Translate recognized constraint/type errors into specific, actionable
+      // 4xx responses instead of a bare "Failed to update event request" 500.
+      const classified = classifyDbError(error);
+      if (classified) {
+        return res.status(classified.status).json({
+          message: classified.message,
+          error: classified.error,
+          column: classified.column,
+          // Keep the raw DB message on the response so error reports remain
+          // diagnosable; it's not shown to the user (the client uses `message`).
+          dbError: pg.message,
         });
       }
 
       res.status(500).json({
         message: 'Failed to update event request',
         error: err?.message || 'Unknown error',
+        dbCode: pg.code,
+        dbColumn: pg.column,
         details: process.env.NODE_ENV === 'development' ? err?.stack : undefined
       });
     }

--- a/server/routes/event-requests-legacy.ts
+++ b/server/routes/event-requests-legacy.ts
@@ -2925,6 +2925,11 @@ router.patch(
               ? dropColumnKey(attemptUpdates, missingColumn)
               : null;
             if (droppedKey && attempt < MAX_COLUMN_DROP_RETRIES) {
+              // Keep processedUpdates in sync with what we actually persist.
+              // Downstream logic (the activity-log change summary, side effects)
+              // keys off processedUpdates, so a dropped-but-still-present field
+              // would be reported as saved when it wasn't.
+              delete (processedUpdates as any)[droppedKey];
               logger.warn(
                 `[PATCH /:id] Column "${missingColumn}" is not on this DB branch; dropping "${droppedKey}" and retrying: ${updateError?.message}`
               );
@@ -3072,15 +3077,20 @@ router.patch(
           message: classified.message,
           error: classified.error,
           column: classified.column,
-          // Keep the raw DB message on the response so error reports remain
-          // diagnosable; it's not shown to the user (the client uses `message`).
+          // Same structured DB detail on both the 4xx and 500 paths so the
+          // client's error report captures the raw message, SQLSTATE code, and
+          // column consistently. None of these are shown to the user (the
+          // client renders `message`).
           dbError: pg.message,
+          dbCode: pg.code,
+          dbColumn: pg.column,
         });
       }
 
       res.status(500).json({
         message: 'Failed to update event request',
         error: err?.message || 'Unknown error',
+        dbError: pg.message,
         dbCode: pg.code,
         dbColumn: pg.column,
         details: process.env.NODE_ENV === 'development' ? err?.stack : undefined

--- a/server/utils/pg-error-utils.ts
+++ b/server/utils/pg-error-utils.ts
@@ -60,20 +60,23 @@ export function parsePgError(error: unknown): PgErrorInfo {
   }
   const err = (error ?? {}) as Record<string, any>;
   const message = typeof err.message === 'string' ? err.message : String(err.message ?? 'Unknown database error');
+  const code = typeof err.code === 'string' ? err.code : undefined;
 
   let column: string | undefined =
     typeof err.column === 'string' && err.column.length > 0 ? err.column : undefined;
 
-  // 42703 (and some driver versions) leave `.column` empty — the name is in the
+  // undefined_column (42703) leaves `.column` empty — the name is only in the
   // message: `column "foo" of relation "event_requests" does not exist` or
-  // `column "foo" does not exist`.
-  if (!column) {
+  // `column "foo" does not exist`. Restrict this message-parsing fallback to
+  // that code so we don't misattribute a column for other errors whose message
+  // merely mentions one (e.g. check-constraint text).
+  if (!column && code === PG_ERROR_CODES.UNDEFINED_COLUMN) {
     const m = message.match(/column "([^"]+)"/i);
     if (m) column = m[1];
   }
 
   return {
-    code: typeof err.code === 'string' ? err.code : undefined,
+    code,
     column,
     constraint: typeof err.constraint === 'string' ? err.constraint : undefined,
     detail: typeof err.detail === 'string' ? err.detail : undefined,

--- a/server/utils/pg-error-utils.ts
+++ b/server/utils/pg-error-utils.ts
@@ -1,0 +1,201 @@
+/**
+ * Utilities for turning raw Postgres/node-postgres errors into actionable API
+ * responses instead of opaque 500s.
+ *
+ * Why this exists: event-request saves (the scheduling form especially) write a
+ * wide, ever-growing set of columns. When a write fails, the driver throws a
+ * low-level error whose useful detail (which column, which constraint) lives in
+ * `.code` / `.column` / `.detail` or is buried in the message. The API route
+ * used to collapse all of these into "Failed to update event request" / a bare
+ * 500, which told neither the user nor whoever reads the error report anything.
+ *
+ * Two things use this:
+ *  1. A retry that gracefully drops columns that exist in the Drizzle schema but
+ *     not on the current database branch (migrations are applied manually per
+ *     Neon branch, so dev and production drift). Those raise 42703
+ *     (undefined_column) and previously failed the ENTIRE save.
+ *  2. A classifier that maps common constraint errors to specific 4xx messages.
+ */
+
+/** Postgres error codes we translate into actionable API responses. */
+export const PG_ERROR_CODES = {
+  UNDEFINED_COLUMN: '42703',
+  NOT_NULL_VIOLATION: '23502',
+  FOREIGN_KEY_VIOLATION: '23503',
+  UNIQUE_VIOLATION: '23505',
+  INVALID_TEXT_REPRESENTATION: '22P02',
+  NUMERIC_VALUE_OUT_OF_RANGE: '22003',
+  STRING_DATA_RIGHT_TRUNCATION: '22001',
+  DATETIME_FIELD_OVERFLOW: '22008',
+} as const;
+
+export interface PgErrorInfo {
+  /** SQLSTATE code, e.g. "42703". Undefined for non-Postgres errors. */
+  code?: string;
+  /** The column named by the error (snake_case), when the driver/message exposes one. */
+  column?: string;
+  /** Constraint name, when present (e.g. a foreign-key or unique constraint). */
+  constraint?: string;
+  /** The driver's `detail` field, when present. */
+  detail?: string;
+  /** Always populated — the raw error message (or a fallback). */
+  message: string;
+}
+
+/** Convert a camelCase Drizzle field name to its snake_case column name. */
+export function camelToSnakeCase(key: string): string {
+  return key.replace(/[A-Z]/g, (m) => `_${m.toLowerCase()}`);
+}
+
+/**
+ * Best-effort structured info from a thrown DB error. Prefers the driver's own
+ * fields (`code`, `column`, `constraint`, `detail`) and falls back to parsing
+ * the message for the column name when the driver didn't set it (notably 42703,
+ * which does not populate `.column`).
+ */
+export function parsePgError(error: unknown): PgErrorInfo {
+  // A thrown string carries its own message and no structured fields.
+  if (typeof error === 'string') {
+    return { message: error };
+  }
+  const err = (error ?? {}) as Record<string, any>;
+  const message = typeof err.message === 'string' ? err.message : String(err.message ?? 'Unknown database error');
+
+  let column: string | undefined =
+    typeof err.column === 'string' && err.column.length > 0 ? err.column : undefined;
+
+  // 42703 (and some driver versions) leave `.column` empty — the name is in the
+  // message: `column "foo" of relation "event_requests" does not exist` or
+  // `column "foo" does not exist`.
+  if (!column) {
+    const m = message.match(/column "([^"]+)"/i);
+    if (m) column = m[1];
+  }
+
+  return {
+    code: typeof err.code === 'string' ? err.code : undefined,
+    column,
+    constraint: typeof err.constraint === 'string' ? err.constraint : undefined,
+    detail: typeof err.detail === 'string' ? err.detail : undefined,
+    message,
+  };
+}
+
+/**
+ * The snake_case column an undefined_column (42703) error refers to, or null if
+ * the error is not an undefined-column error (or the column can't be recovered).
+ */
+export function getUndefinedColumn(error: unknown): string | null {
+  const info = parsePgError(error);
+  if (info.code !== PG_ERROR_CODES.UNDEFINED_COLUMN) return null;
+  return info.column ?? null;
+}
+
+/**
+ * Remove from `updates` the key whose column maps to `snakeColumn`, mutating the
+ * object. Matching is done on the snake_case form so a camelCase Drizzle key
+ * (e.g. `addedToOfficialSheetAt`) matches the DB column (`added_to_official_sheet_at`).
+ * Returns the removed camelCase key, or null when nothing matched.
+ */
+export function dropColumnKey(updates: Record<string, any>, snakeColumn: string): string | null {
+  const target = snakeColumn.toLowerCase();
+  for (const key of Object.keys(updates)) {
+    if (camelToSnakeCase(key).toLowerCase() === target || key.toLowerCase() === target) {
+      delete updates[key];
+      return key;
+    }
+  }
+  return null;
+}
+
+/** Turn a snake_case / camelCase column into a human-readable field label. */
+export function humanizeColumn(column: string | undefined): string {
+  if (!column) return 'a field';
+  return column
+    .replace(/[A-Z]/g, (m) => ` ${m.toLowerCase()}`)
+    .replace(/_/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export interface ClassifiedDbError {
+  /** HTTP status to respond with. */
+  status: number;
+  /** User-facing message. */
+  message: string;
+  /** Stable error code for the client to branch on. */
+  error: string;
+  /** The column involved, when known (for the client / error report). */
+  column?: string;
+}
+
+/**
+ * Map a DB error to an actionable HTTP response. Returns null when the error is
+ * not a recognized constraint/type error, so the caller keeps its generic 500.
+ */
+export function classifyDbError(error: unknown): ClassifiedDbError | null {
+  const info = parsePgError(error);
+  const field = humanizeColumn(info.column);
+
+  // Some deployments surface type errors only in the message (no SQLSTATE).
+  const looksLikeInvalidSyntax =
+    info.code === PG_ERROR_CODES.INVALID_TEXT_REPRESENTATION ||
+    /invalid input syntax/i.test(info.message);
+
+  if (looksLikeInvalidSyntax) {
+    return {
+      status: 400,
+      message: 'One of the fields has an invalid value. Please check numbers and dates and try again.',
+      error: 'INVALID_DATA_FORMAT',
+      column: info.column,
+    };
+  }
+
+  switch (info.code) {
+    case PG_ERROR_CODES.NOT_NULL_VIOLATION:
+      return {
+        status: 400,
+        message: `The field "${field}" is required and can't be left empty.`,
+        error: 'REQUIRED_FIELD_MISSING',
+        column: info.column,
+      };
+    case PG_ERROR_CODES.NUMERIC_VALUE_OUT_OF_RANGE:
+      return {
+        status: 400,
+        message: 'A number you entered is too large. Please enter a smaller value.',
+        error: 'NUMBER_OUT_OF_RANGE',
+        column: info.column,
+      };
+    case PG_ERROR_CODES.STRING_DATA_RIGHT_TRUNCATION:
+      return {
+        status: 400,
+        message: 'One of the text fields is too long. Please shorten it and try again.',
+        error: 'VALUE_TOO_LONG',
+        column: info.column,
+      };
+    case PG_ERROR_CODES.DATETIME_FIELD_OVERFLOW:
+      return {
+        status: 400,
+        message: 'One of the dates is invalid. Please re-check the date fields.',
+        error: 'INVALID_DATE',
+        column: info.column,
+      };
+    case PG_ERROR_CODES.FOREIGN_KEY_VIOLATION:
+      return {
+        status: 400,
+        message:
+          'A linked record (driver, speaker, or recipient) no longer exists. Please refresh the page and reselect it.',
+        error: 'LINKED_RECORD_MISSING',
+        column: info.column,
+      };
+    case PG_ERROR_CODES.UNIQUE_VIOLATION:
+      return {
+        status: 409,
+        message: 'That value is already in use by another record.',
+        error: 'DUPLICATE_VALUE',
+        column: info.column,
+      };
+    default:
+      return null;
+  }
+}

--- a/tests/unit/pg-error-utils.test.ts
+++ b/tests/unit/pg-error-utils.test.ts
@@ -1,0 +1,122 @@
+import {
+  camelToSnakeCase,
+  parsePgError,
+  getUndefinedColumn,
+  dropColumnKey,
+  humanizeColumn,
+  classifyDbError,
+  PG_ERROR_CODES,
+} from '../../server/utils/pg-error-utils';
+
+/** Build a fake node-postgres error. */
+function pgError(fields: Record<string, any>): Error {
+  return Object.assign(new Error(fields.message ?? 'db error'), fields);
+}
+
+describe('camelToSnakeCase', () => {
+  it('converts camelCase Drizzle keys to snake_case columns', () => {
+    expect(camelToSnakeCase('addedToOfficialSheetAt')).toBe('added_to_official_sheet_at');
+    expect(camelToSnakeCase('status')).toBe('status');
+    expect(camelToSnakeCase('scheduledEventDate')).toBe('scheduled_event_date');
+  });
+});
+
+describe('parsePgError', () => {
+  it('prefers the driver-provided column', () => {
+    const info = parsePgError(pgError({ code: '23502', column: 'organization_name', message: 'null value' }));
+    expect(info.code).toBe('23502');
+    expect(info.column).toBe('organization_name');
+  });
+
+  it('recovers the column from the message when the driver omits it (42703)', () => {
+    const info = parsePgError(
+      pgError({ code: '42703', message: 'column "added_to_official_sheet_at" of relation "event_requests" does not exist' })
+    );
+    expect(info.column).toBe('added_to_official_sheet_at');
+  });
+
+  it('never throws on non-Postgres / empty errors', () => {
+    expect(parsePgError(undefined).message).toBeDefined();
+    expect(parsePgError(null).code).toBeUndefined();
+    expect(parsePgError('boom').message).toBe('boom');
+  });
+});
+
+describe('getUndefinedColumn', () => {
+  it('returns the column only for undefined_column (42703)', () => {
+    expect(
+      getUndefinedColumn(pgError({ code: '42703', message: 'column "van_needed_likely" does not exist' }))
+    ).toBe('van_needed_likely');
+    expect(getUndefinedColumn(pgError({ code: '23502', column: 'x', message: 'not null' }))).toBeNull();
+    expect(getUndefinedColumn(new Error('random'))).toBeNull();
+  });
+});
+
+describe('dropColumnKey', () => {
+  it('removes the camelCase key matching a snake_case column and returns it', () => {
+    const updates: Record<string, any> = { status: 'scheduled', addedToOfficialSheetAt: new Date(), foo: 1 };
+    const removed = dropColumnKey(updates, 'added_to_official_sheet_at');
+    expect(removed).toBe('addedToOfficialSheetAt');
+    expect(updates).not.toHaveProperty('addedToOfficialSheetAt');
+    expect(updates).toHaveProperty('status');
+  });
+
+  it('matches a key that is already snake_case', () => {
+    const updates: Record<string, any> = { some_column: 1 };
+    expect(dropColumnKey(updates, 'some_column')).toBe('some_column');
+  });
+
+  it('returns null when no key maps to the column', () => {
+    const updates: Record<string, any> = { status: 'scheduled' };
+    expect(dropColumnKey(updates, 'nonexistent_column')).toBeNull();
+    expect(updates).toHaveProperty('status');
+  });
+});
+
+describe('humanizeColumn', () => {
+  it('produces a readable label from snake_case or camelCase', () => {
+    expect(humanizeColumn('organization_name')).toBe('organization name');
+    expect(humanizeColumn('scheduledEventDate')).toBe('scheduled event date');
+    expect(humanizeColumn(undefined)).toBe('a field');
+  });
+});
+
+describe('classifyDbError', () => {
+  it('classifies not-null violations as an actionable 400 naming the field', () => {
+    const c = classifyDbError(pgError({ code: PG_ERROR_CODES.NOT_NULL_VIOLATION, column: 'organization_name', message: 'null value' }));
+    expect(c?.status).toBe(400);
+    expect(c?.error).toBe('REQUIRED_FIELD_MISSING');
+    expect(c?.message).toContain('organization name');
+  });
+
+  it('classifies invalid input syntax (by message, no code) as 400', () => {
+    const c = classifyDbError(new Error('invalid input syntax for type integer: "abc"'));
+    expect(c?.status).toBe(400);
+    expect(c?.error).toBe('INVALID_DATA_FORMAT');
+  });
+
+  it('classifies numeric overflow as 400', () => {
+    const c = classifyDbError(pgError({ code: PG_ERROR_CODES.NUMERIC_VALUE_OUT_OF_RANGE, message: 'out of range' }));
+    expect(c?.status).toBe(400);
+    expect(c?.error).toBe('NUMBER_OUT_OF_RANGE');
+  });
+
+  it('classifies foreign-key violations as 400', () => {
+    const c = classifyDbError(pgError({ code: PG_ERROR_CODES.FOREIGN_KEY_VIOLATION, message: 'fk' }));
+    expect(c?.status).toBe(400);
+    expect(c?.error).toBe('LINKED_RECORD_MISSING');
+  });
+
+  it('classifies unique violations as 409', () => {
+    const c = classifyDbError(pgError({ code: PG_ERROR_CODES.UNIQUE_VIOLATION, message: 'dup' }));
+    expect(c?.status).toBe(409);
+  });
+
+  it('returns null for undefined_column (handled by drop-and-retry, not the catch)', () => {
+    expect(classifyDbError(pgError({ code: PG_ERROR_CODES.UNDEFINED_COLUMN, message: 'column "x" does not exist' }))).toBeNull();
+  });
+
+  it('returns null for unrecognized errors so the caller keeps its generic 500', () => {
+    expect(classifyDbError(new Error('some unexpected failure'))).toBeNull();
+  });
+});

--- a/tests/unit/pg-error-utils.test.ts
+++ b/tests/unit/pg-error-utils.test.ts
@@ -101,6 +101,20 @@ describe('classifyDbError', () => {
     expect(c?.error).toBe('NUMBER_OUT_OF_RANGE');
   });
 
+  it('classifies string-too-long (22001) as 400', () => {
+    const c = classifyDbError(
+      pgError({ code: PG_ERROR_CODES.STRING_DATA_RIGHT_TRUNCATION, message: 'value too long for type character varying(10)' })
+    );
+    expect(c?.status).toBe(400);
+    expect(c?.error).toBe('VALUE_TOO_LONG');
+  });
+
+  it('classifies datetime overflow (22008) as 400', () => {
+    const c = classifyDbError(pgError({ code: PG_ERROR_CODES.DATETIME_FIELD_OVERFLOW, message: 'date/time field value out of range' }));
+    expect(c?.status).toBe(400);
+    expect(c?.error).toBe('INVALID_DATE');
+  });
+
   it('classifies foreign-key violations as 400', () => {
     const c = classifyDbError(pgError({ code: PG_ERROR_CODES.FOREIGN_KEY_VIOLATION, message: 'fk' }));
     expect(c?.status).toBe(400);


### PR DESCRIPTION
## Summary
Replaces opaque 500 errors from database constraint/type violations with specific, user-friendly 4xx responses. Adds a new utility module (`pg-error-utils.ts`) that parses Postgres error codes and details, classifies them into actionable messages, and handles graceful retry when columns exist in the Drizzle schema but not yet on the current database branch (due to manual per-branch migrations on Neon).

## Key Changes

### New Module: `server/utils/pg-error-utils.ts`
- **Error parsing**: `parsePgError()` extracts structured info (code, column, constraint, detail) from thrown errors, with fallback message parsing for drivers that don't populate all fields
- **Column recovery**: Handles Postgres 42703 (undefined_column) errors by parsing the column name from the error message when the driver doesn't provide it
- **Column dropping**: `dropColumnKey()` removes camelCase Drizzle keys matching snake_case DB columns, enabling retry logic
- **Error classification**: `classifyDbError()` maps 8 common Postgres error codes to specific HTTP responses:
  - 23502 (NOT NULL) → 400 `REQUIRED_FIELD_MISSING`
  - 23503 (FOREIGN KEY) → 400 `LINKED_RECORD_MISSING`
  - 23505 (UNIQUE) → 409 `DUPLICATE_VALUE`
  - 22P02 (INVALID TEXT) → 400 `INVALID_DATA_FORMAT`
  - 22003 (NUMERIC OVERFLOW) → 400 `NUMBER_OUT_OF_RANGE`
  - 22001 (STRING TRUNCATION) → 400 `VALUE_TOO_LONG`
  - 22008 (DATETIME OVERFLOW) → 400 `INVALID_DATE`
- **Human-readable labels**: `humanizeColumn()` converts snake_case/camelCase column names to user-facing field labels

### Updated: `server/routes/event-requests-legacy.ts`
- **Graceful column dropping**: Replaced hardcoded `addedToOfficialSheetAt` retry with a loop that detects any undefined_column (42703) error, drops the offending column, and retries (up to 12 times to prevent infinite loops)
- **Structured error logging**: Logs DB error code, column, and constraint to server logs so the real cause is recoverable even when the client sees a friendly message
- **Error classification in catch block**: Uses `classifyDbError()` to return specific 4xx responses for constraint/type errors instead of generic 500s
- **Enhanced error response**: Includes `dbError` (raw message), `dbCode`, and `dbColumn` fields for error reports and debugging

### Updated: `client/src/components/event-requests/EventSchedulingForm.tsx`
- **Structured error reporting**: Captures server's DB detail (`dbError`, `dbCode`, `dbColumn`) and includes it in auto-filed error reports
- **Better error context**: Error report now includes `expectedOutcome` and `actualOutcome` with DB details so support can diagnose the real cause

### New Tests: `tests/unit/pg-error-utils.test.ts`
- 122 lines of unit tests covering all utility functions
- Tests error parsing, column recovery, key dropping, humanization, and classification logic
- Validates that unrecognized errors return null (so caller keeps generic 500)

## Implementation Details

**Why this matters**: Event request saves write a wide, ever-growing set of columns. When a write fails, the driver throws a low-level error whose useful detail (which column, which constraint) lives in `.code` / `.column` / `.detail` or is buried in the message. The old code collapsed all of these into "Failed to update event request" / a bare 500.

**Column drift handling**: Migrations are applied manually per Neon branch (dev and production drift). A column may exist in the Drizzle schema but not yet on the current DB branch. The new retry loop detects 42703 (undefined_column), drops the missing column from the update, records it for the client's partial-save warning, and retries. This prevents the entire save from failing when one column

https://claude.ai/code/session_01PavHun8juj44rwgTbFQpwf