### PR TITLE
Fix OpenAI gpt-5 API errors: max_completion_tokens and default temperature

### DIFF
--- a/server/routes/alert-requests.ts
+++ b/server/routes/alert-requests.ts
@@ -298,7 +298,6 @@ Be concise and practical. Frame the response as a well-written alert request tha
           },
         ],
         max_completion_tokens: 500,
-        temperature: 0.7,
       });
 
       const generatedAlert = completion.choices[0]?.message?.content || 'Unable to generate suggestion';

--- a/server/routes/alert-requests.ts
+++ b/server/routes/alert-requests.ts
@@ -297,7 +297,7 @@ Be concise and practical. Frame the response as a well-written alert request tha
             content: `Help me create an alert for the following: ${prompt}`,
           },
         ],
-        max_tokens: 500,
+        max_completion_tokens: 500,
         temperature: 0.7,
       });
 

--- a/server/scripts/auto-categorize-organizations-with-ai.ts
+++ b/server/scripts/auto-categorize-organizations-with-ai.ts
@@ -57,7 +57,6 @@ Do not include any explanation or additional text.`,
           content: `Categorize this organization: "${organizationName}"`,
         },
       ],
-      temperature: 0.1,
       max_completion_tokens: 100,
     });
 

--- a/server/scripts/auto-categorize-organizations-with-ai.ts
+++ b/server/scripts/auto-categorize-organizations-with-ai.ts
@@ -58,7 +58,7 @@ Do not include any explanation or additional text.`,
         },
       ],
       temperature: 0.1,
-      max_tokens: 100,
+      max_completion_tokens: 100,
     });
 
     const response = completion.choices[0]?.message?.content?.trim();

--- a/server/scripts/test-ai-categorization.ts
+++ b/server/scripts/test-ai-categorization.ts
@@ -38,7 +38,7 @@ Do not include any explanation or additional text.`,
         },
       ],
       temperature: 0.1,
-      max_tokens: 100,
+      max_completion_tokens: 100,
     });
 
     const response = completion.choices[0]?.message?.content?.trim();

--- a/server/scripts/test-ai-categorization.ts
+++ b/server/scripts/test-ai-categorization.ts
@@ -37,7 +37,6 @@ Do not include any explanation or additional text.`,
           content: `Categorize this organization: "${organizationName}"`,
         },
       ],
-      temperature: 0.1,
       max_completion_tokens: 100,
     });
 

--- a/server/services/ai-event-categorization/index.ts
+++ b/server/services/ai-event-categorization/index.ts
@@ -137,7 +137,6 @@ Return your analysis as a JSON object with this structure:
         },
       ],
       response_format: { type: 'json_object' },
-      temperature: 0.3, // Lower temperature for more consistent categorization
       max_completion_tokens: 500,
     });
 

--- a/server/services/ai-event-categorization/index.ts
+++ b/server/services/ai-event-categorization/index.ts
@@ -138,7 +138,7 @@ Return your analysis as a JSON object with this structure:
       ],
       response_format: { type: 'json_object' },
       temperature: 0.3, // Lower temperature for more consistent categorization
-      max_tokens: 500,
+      max_completion_tokens: 500,
     });
 
     const responseContent = completion.choices[0].message.content;

--- a/server/services/ai-intake-assistant/index.ts
+++ b/server/services/ai-intake-assistant/index.ts
@@ -683,7 +683,6 @@ Provide 2-3 specific, actionable recommendations based on the current state of t
         content: prompt
       }
     ],
-    temperature: 0.7,
     max_completion_tokens: 300,
   });
 

--- a/server/services/ai-intake-assistant/index.ts
+++ b/server/services/ai-intake-assistant/index.ts
@@ -684,7 +684,7 @@ Provide 2-3 specific, actionable recommendations based on the current state of t
       }
     ],
     temperature: 0.7,
-    max_tokens: 300,
+    max_completion_tokens: 300,
   });
 
   return completion.choices[0].message.content || '';

--- a/server/services/ai-organization-categorization/index.ts
+++ b/server/services/ai-organization-categorization/index.ts
@@ -136,7 +136,7 @@ Return JSON in this exact format:
       ],
       response_format: { type: 'json_object' },
       temperature: 0.1,
-      max_tokens: 200,
+      max_completion_tokens: 200,
     });
 
     const response = completion.choices[0]?.message?.content?.trim();

--- a/server/services/ai-organization-categorization/index.ts
+++ b/server/services/ai-organization-categorization/index.ts
@@ -135,7 +135,6 @@ Return JSON in this exact format:
         },
       ],
       response_format: { type: 'json_object' },
-      temperature: 0.1,
       max_completion_tokens: 200,
     });
 

--- a/server/services/ai-predictions/index.ts
+++ b/server/services/ai-predictions/index.ts
@@ -180,7 +180,6 @@ Current trend: ${trend}
         },
       ],
       response_format: { type: 'json_object' },
-      temperature: 0.3,
       max_completion_tokens: 500,
     });
 

--- a/server/services/ai-predictions/index.ts
+++ b/server/services/ai-predictions/index.ts
@@ -181,7 +181,7 @@ Current trend: ${trend}
       ],
       response_format: { type: 'json_object' },
       temperature: 0.3,
-      max_tokens: 500,
+      max_completion_tokens: 500,
     });
 
     const content = completion.choices[0].message.content;

--- a/server/services/ai-scheduling/index.ts
+++ b/server/services/ai-scheduling/index.ts
@@ -102,7 +102,7 @@ You must respond with a JSON object containing exactly these fields:
       ],
       response_format: { type: "json_object" },
       temperature: 0.7,
-      max_tokens: 500,
+      max_completion_tokens: 500,
     });
 
     const aiResponse = completion.choices[0].message.content || '';

--- a/server/services/ai-scheduling/index.ts
+++ b/server/services/ai-scheduling/index.ts
@@ -101,7 +101,6 @@ You must respond with a JSON object containing exactly these fields:
         }
       ],
       response_format: { type: "json_object" },
-      temperature: 0.7,
       max_completion_tokens: 500,
     });
 

--- a/server/services/integration-health.ts
+++ b/server/services/integration-health.ts
@@ -51,7 +51,7 @@ async function pingOpenAI(
     const start = Date.now();
     await client.chat.completions.create({
       model: 'gpt-5-mini',
-      max_tokens: 5,
+      max_completion_tokens: 5,
       messages: [{ role: 'user', content: 'Reply with OK' }],
     });
 

--- a/server/services/sms-collection-parser.ts
+++ b/server/services/sms-collection-parser.ts
@@ -389,7 +389,7 @@ async function parseWithAI(message: string): Promise<CollectionParseResult> {
       model: 'gpt-5-mini',
       response_format: { type: 'json_object' },
       temperature: 0.1,
-      max_tokens: 500,
+      max_completion_tokens: 500,
       messages: [
         {
           role: 'system',

--- a/server/services/sms-collection-parser.ts
+++ b/server/services/sms-collection-parser.ts
@@ -388,7 +388,6 @@ async function parseWithAI(message: string): Promise<CollectionParseResult> {
     const response = await client.chat.completions.create({
       model: 'gpt-5-mini',
       response_format: { type: 'json_object' },
-      temperature: 0.1,
       max_completion_tokens: 500,
       messages: [
         {


### PR DESCRIPTION
## Summary
Fixes 400 errors from the `gpt-5` / `gpt-5-mini` models, which reject two parameters the code was still sending:
1. `max_tokens` — these models require `max_completion_tokens` instead. This is what broke the SMS collection parser (the originally reported error).
2. non-default `temperature` — these models only accept the default (`1`) and 400 on any other value.

## Changes
**Rename `max_tokens` → `max_completion_tokens`** on all OpenAI (gpt-5) call sites:
- `server/services/sms-collection-parser.ts` (the reported failure)
- `server/services/integration-health.ts`
- `server/services/ai-event-categorization/index.ts`
- `server/services/ai-intake-assistant/index.ts`
- `server/services/ai-organization-categorization/index.ts`
- `server/services/ai-predictions/index.ts`
- `server/services/ai-scheduling/index.ts`
- `server/routes/alert-requests.ts`
- `server/scripts/auto-categorize-organizations-with-ai.ts`
- `server/scripts/test-ai-categorization.ts`

**Remove unsupported `temperature`** (was 0.1–0.7) from those same gpt-5 calls so they fall back to the required default of `1`.

## Scope note
This rename is intentionally **scoped to OpenAI calls only**. `server/services/signin-sheet-parser.ts` still uses `max_tokens` on purpose — it calls the Anthropic (Claude) API via `client.messages.create`, where `max_tokens` is the correct and required parameter. The two gpt-5 calls that already worked (`ai-impact-reports`, `ai-receipt-processor`) already used `max_completion_tokens` and never set `temperature`, confirming the expected shape.

## Implementation Details
- No functional changes to logic or behavior beyond the parameter fixes
- Token limits are unchanged; only the parameter name changed
- `temperature` removed rather than pinned to `1`, matching the working call sites

https://claude.ai/code/session_01Sz2mNGsgtRBffjEYeYh5xD

🤖 Generated with [Claude Code](https://claude.com/claude-code)