### PR TITLE
Fix sandwich count midpoint drift and cancelled status saves

### DIFF
--- a/client/src/components/event-requests/EventSchedulingForm.tsx
+++ b/client/src/components/event-requests/EventSchedulingForm.tsx
@@ -35,6 +35,7 @@ import { useEventCollaboration } from '@/hooks/use-event-collaboration';
 import { getEventRequestSourceIndicator } from '@/lib/event-request-source';
 import { PresenceAvatars } from '@/components/collaboration';
 import { RefrigerationWarningAlert } from './RefrigerationWarningBadge';
+import { StatusReasonDialog } from './dialogs/StatusReasonDialog';
 import {
   ContactInfoSection,
   BackupContactSection,
@@ -230,6 +231,10 @@ function buildFormDataFromEventRequest(
     followUpOneMonthDate: (eventRequest as any)?.followUpOneMonthDate ? formatDateForInput((eventRequest as any).followUpOneMonthDate) : '',
     followUpNotes: (eventRequest as any)?.followUpNotes || '',
     assignedRecipientIds: parsePostgresArrayFn((eventRequest as any)?.assignedRecipientIds),
+    cancelledReason: (eventRequest as any)?.cancelledReason || '',
+    cancelledNotes: (eventRequest as any)?.cancelledNotes || '',
+    declinedReason: (eventRequest as any)?.declinedReason || '',
+    declinedNotes: (eventRequest as any)?.declinedNotes || '',
   };
 }
 
@@ -306,6 +311,7 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
     backupContactPhone: '', backupContactRole: '', previouslyHosted: 'i_dont_know',
     deliveryTimeWindow: '',
     deliveryParkingAccess: '', isCorporatePriority: false, standbyExpectedDate: '',
+    cancelledReason: '', cancelledNotes: '', declinedReason: '', declinedNotes: '',
     dateFlexible: null as boolean | null,
   });
 
@@ -336,6 +342,8 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
   const [vanConflictChecked, setVanConflictChecked] = useState(false);
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const [showStandbyFollowUpDialog, setShowStandbyFollowUpDialog] = useState(false);
+  const [showStatusReasonDialog, setShowStatusReasonDialog] = useState(false);
+  const [pendingReasonStatus, setPendingReasonStatus] = useState<'cancelled' | 'declined' | null>(null);
   const [standbyFollowUpDate, setStandbyFollowUpDate] = useState('');
   const [standbyFollowUpMode, setStandbyFollowUpMode] = useState<'specific' | 'one_week' | 'none'>('one_week');
   const standbySaveClickedRef = useRef(false);
@@ -1135,25 +1143,31 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
         const hasReason = reasonFields.some((field) => {
           const incoming = (eventData as any)[field];
           const existing = (eventRequest as any)[field];
-          const formValue =
-            field === 'planningNotes'
-              ? formData.planningNotes
-              : field === 'schedulingNotes'
-                ? formData.schedulingNotes
-                : undefined;
+          const formValue = (formData as any)[field];
           const effective =
-            incoming !== undefined ? incoming : (formValue !== undefined ? formValue : existing);
+            incoming !== undefined
+              ? incoming
+              : formValue !== undefined && formValue !== ''
+                ? formValue
+                : existing;
           return typeof effective === 'string' && effective.trim() !== '';
         });
         if (!hasReason) {
           logger.log('⛔ Save blocked: missing reason for', targetStatus);
           setIsSubmitting(false);
+          // If they somehow picked cancelled/declined without going through the
+          // reason dialog (e.g. recovered draft), open it now instead of a toast.
+          if (
+            (targetStatus === 'cancelled' || targetStatus === 'declined') &&
+            eventRequest
+          ) {
+            setPendingReasonStatus(targetStatus);
+            setTimeout(() => setShowStatusReasonDialog(true), 0);
+            return;
+          }
           toast({
             title: 'Reason required',
-            description:
-              targetStatus === 'cancelled'
-                ? 'Add a brief cancellation reason in Planning Notes or Scheduling Notes, then save — or use Cancel Event on the card.'
-                : `Add a brief reason in Planning Notes or Scheduling Notes before marking this event as ${STATUS_DEFINITIONS[targetStatus]?.label || targetStatus}.`,
+            description: `Add a brief reason before marking this event as ${STATUS_DEFINITIONS[targetStatus]?.label || targetStatus}.`,
             variant: 'destructive',
             duration: 10000,
           });
@@ -1188,14 +1202,30 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
   // ── Status Change Handler ──────────────────────────────────────────
 
   const handleStatusChange = (newStatus: EventStatus) => {
-    if (newStatus === 'cancelled' || newStatus === 'declined' || newStatus === 'non_event' || newStatus === 'rescheduled') {
+    // Cancelled / Declined require a structured reason (server MISSING_REASON).
+    // Open the reason dialog first; only apply the status once the user confirms.
+    // Defer open so the parent non-modal Dialog doesn't tear down on focus churn
+    // (same pattern as the standby follow-up dialog).
+    if (newStatus === 'cancelled' || newStatus === 'declined') {
+      if (!eventRequest) {
+        toast({
+          title: 'Reason required',
+          description: `Add a brief reason in Planning Notes or Scheduling Notes before marking this as ${STATUS_DEFINITIONS[newStatus]?.label || newStatus}.`,
+          duration: 8000,
+        });
+        setFormData(prev => ({ ...prev, status: newStatus }));
+        return;
+      }
+      setPendingReasonStatus(newStatus);
+      setTimeout(() => setShowStatusReasonDialog(true), 0);
+      return;
+    }
+
+    if (newStatus === 'non_event' || newStatus === 'rescheduled') {
       const statusLabel = STATUS_DEFINITIONS[newStatus]?.label || newStatus;
       toast({
         title: 'Status Change Requires Documentation',
-        description:
-          newStatus === 'cancelled'
-            ? `Before saving as ${statusLabel}, add a brief reason in Planning Notes or Scheduling Notes (or use Cancel Event on the card).`
-            : `When saving, please ensure you've documented the reason for changing to ${statusLabel} in the notes field.`,
+        description: `When saving, please ensure you've documented the reason for changing to ${statusLabel} in the notes field.`,
         duration: 8000,
       });
     }
@@ -1295,6 +1325,7 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
     showDateConfirmation ||
     showVanConflictDialog ||
     showStandbyFollowUpDialog ||
+    showStatusReasonDialog ||
     showDeleteConfirmation;
 
   // ── Render ─────────────────────────────────────────────────────────
@@ -1727,6 +1758,37 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
           }
         }}
       />
+
+      {eventRequest && pendingReasonStatus && (
+        <StatusReasonDialog
+          isOpen={showStatusReasonDialog}
+          onClose={() => {
+            setShowStatusReasonDialog(false);
+            setPendingReasonStatus(null);
+          }}
+          request={eventRequest}
+          type={pendingReasonStatus}
+          onConfirm={async (_eventId, data) => {
+            // Stash status + structured reason on the form; Save will send them
+            // together and satisfy the server MISSING_REASON check (Susan's bug).
+            setFormData((prev) => ({
+              ...prev,
+              status: data.status,
+              cancelledReason: data.cancelledReason || '',
+              cancelledNotes: data.cancelledNotes || '',
+              declinedReason: data.declinedReason || '',
+              declinedNotes: data.declinedNotes || '',
+            }));
+            setShowStatusReasonDialog(false);
+            setPendingReasonStatus(null);
+            toast({
+              title: `${STATUS_DEFINITIONS[data.status as EventStatus]?.label || data.status} reason recorded`,
+              description: 'Click Save to apply the status change.',
+              duration: 6000,
+            });
+          }}
+        />
+      )}
 
       <DeleteConfirmDialog
         open={showDeleteConfirmation}

--- a/client/src/components/event-requests/EventSchedulingForm.tsx
+++ b/client/src/components/event-requests/EventSchedulingForm.tsx
@@ -27,6 +27,7 @@ import { apiRequest, invalidateEventRequestQueries, applyEventRequestSaveToCache
 import type { EventRequest } from '@shared/schema';
 import { STATUS_DEFINITIONS } from './constants';
 import type { EventStatus } from '@shared/event-status-workflow';
+import { requiresReason, getReasonSatisfyingFields } from '@shared/event-status-workflow';
 import { getPickupDateTimeForInput, parsePostgresArray } from './utils';
 import { logger } from '@/lib/logger';
 import { useAuth } from '@/hooks/useAuth';
@@ -1121,6 +1122,45 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
         return;
       }
 
+      // Reason-required statuses (cancelled / declined / non_event) need a note
+      // or structured reason. Catch this client-side so users get a clear message
+      // instead of a generic MISSING_REASON failure from the server.
+      const targetStatus = eventData.status as EventStatus | undefined;
+      if (
+        targetStatus &&
+        targetStatus !== eventRequest.status &&
+        requiresReason(targetStatus)
+      ) {
+        const reasonFields = getReasonSatisfyingFields(targetStatus);
+        const hasReason = reasonFields.some((field) => {
+          const incoming = (eventData as any)[field];
+          const existing = (eventRequest as any)[field];
+          const formValue =
+            field === 'planningNotes'
+              ? formData.planningNotes
+              : field === 'schedulingNotes'
+                ? formData.schedulingNotes
+                : undefined;
+          const effective =
+            incoming !== undefined ? incoming : (formValue !== undefined ? formValue : existing);
+          return typeof effective === 'string' && effective.trim() !== '';
+        });
+        if (!hasReason) {
+          logger.log('⛔ Save blocked: missing reason for', targetStatus);
+          setIsSubmitting(false);
+          toast({
+            title: 'Reason required',
+            description:
+              targetStatus === 'cancelled'
+                ? 'Add a brief cancellation reason in Planning Notes or Scheduling Notes, then save — or use Cancel Event on the card.'
+                : `Add a brief reason in Planning Notes or Scheduling Notes before marking this event as ${STATUS_DEFINITIONS[targetStatus]?.label || targetStatus}.`,
+            variant: 'destructive',
+            duration: 10000,
+          });
+          return;
+        }
+      }
+
       logger.log('🔄 Updating event (diff-based save):', eventRequest.id, 'changed field count:', Object.keys(eventData).length, 'van:', eventData.vanDriverNeeded);
       // Extra status-transition diagnostic: any standby-related save logs the
       // exact status payload being sent. Helps debug the "save closes but
@@ -1152,8 +1192,11 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
       const statusLabel = STATUS_DEFINITIONS[newStatus]?.label || newStatus;
       toast({
         title: 'Status Change Requires Documentation',
-        description: `When saving, please ensure you've documented the reason for changing to ${statusLabel} in the notes field.`,
-        duration: 6000,
+        description:
+          newStatus === 'cancelled'
+            ? `Before saving as ${statusLabel}, add a brief reason in Planning Notes or Scheduling Notes (or use Cancel Event on the card).`
+            : `When saving, please ensure you've documented the reason for changing to ${statusLabel} in the notes field.`,
+        duration: 8000,
       });
     }
     setFormData(prev => ({ ...prev, status: newStatus }));

--- a/client/src/components/event-requests/EventSchedulingForm.tsx
+++ b/client/src/components/event-requests/EventSchedulingForm.tsx
@@ -58,6 +58,7 @@ import {
   findMismatchedSavedFields,
   getDroppedServerFields,
   determineSandwichMode,
+  determineBaselineSandwichMode,
   determineActualSandwichMode,
 } from './form-utils';
 
@@ -1062,15 +1063,14 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
       // WITHOUT fieldOverrides so a value just entered this session (e.g. the
       // standby follow-up date) correctly registers as a change.
       if (originalFormDataRef.current) {
-        // The baseline MUST be serialized in the mode the data was ORIGINALLY
-        // in, not the mode the form is in now. Serializing the baseline with the
-        // current mode would force its companion fields (range min/max,
-        // sandwichTypes) to null too — so when the user switches e.g. Range →
-        // Exact Count, the diff sees null === null and silently drops the very
-        // fields that clear the stale range. The stale range then survives in the
-        // DB and getReportableSandwichCount keeps showing its midpoint instead of
-        // the exact count the user entered (the "500 saves as 498" bug).
-        const baselineSandwichMode = determineSandwichMode(
+        // The baseline MUST be serialized from what is PHYSICALLY stored, not
+        // the preferred UI mode. determineBaselineSandwichMode treats any
+        // persisted min/max as 'range' even when a disagreeing exact count means
+        // the UI opens in Exact Count — otherwise the diff sees null === null
+        // for the companion clears and silently drops them. The stale range then
+        // survives in the DB alongside the exact count (the "500 saves as 498"
+        // bug — midpoint of a leftover 490-506 range).
+        const baselineSandwichMode = determineBaselineSandwichMode(
           originalFormDataRef.current.sandwichTypes,
           originalFormDataRef.current.estimatedSandwichCountMin,
           originalFormDataRef.current.estimatedSandwichCountMax,

--- a/client/src/components/event-requests/__tests__/mark-scheduled-save.test.ts
+++ b/client/src/components/event-requests/__tests__/mark-scheduled-save.test.ts
@@ -6,6 +6,7 @@ import {
   getDroppedServerFields,
   buildEventDataForServer,
   determineSandwichMode,
+  determineBaselineSandwichMode,
   determineActualSandwichMode,
   sumSandwichTypeQuantities,
 } from '../form-utils';
@@ -189,6 +190,24 @@ describe('determineSandwichMode (sandwich count drift)', () => {
     ).toBe('types');
   });
 
+  it('prefers Exact Count when exact disagrees with stale range midpoint (500 vs 498)', () => {
+    expect(
+      determineSandwichMode([], 490, 506, 500),
+    ).toBe('total');
+  });
+
+  it('keeps Range when exact equals the range midpoint (legitimate import)', () => {
+    expect(
+      determineSandwichMode([], 490, 506, 498),
+    ).toBe('range');
+  });
+
+  it('keeps Range when there is no exact count', () => {
+    expect(
+      determineSandwichMode([], 490, 506, null),
+    ).toBe('range');
+  });
+
   it('clears types semantics in total-mode full-form save payload', () => {
     const payload = buildEventDataForServer(
       {
@@ -254,11 +273,10 @@ describe('determineSandwichMode (sandwich count drift)', () => {
 /**
  * Regression coverage for the "500 saves as 498" bug.
  *
- * getReportableSandwichCount resolves a range midpoint BEFORE
- * estimatedSandwichCount, so a stale estimatedSandwichCountMin/Max left in the DB
- * makes the display revert to the range midpoint no matter what exact count the
- * user typed. The diff-based save must therefore actually SEND the null-out of
- * those range fields when the user switches Range -> Exact Count.
+ * A stale estimatedSandwichCountMin/Max left in the DB alongside an exact
+ * count used to win on display (range midpoint 498 over exact 500). The
+ * diff-based save must therefore SEND the null-out of those range fields when
+ * the user switches Range -> Exact Count.
  *
  * The bug was that the diff baseline was serialized in the CURRENT (total) mode,
  * which also nulled min/max — so the diff saw null === null and dropped the
@@ -277,7 +295,7 @@ describe('diff-based save clears stale range on Range -> Exact Count (500 -> 498
     };
     const eventData = buildEventDataForServer(currentFormData, { ...opts, sandwichMode: currentSandwichMode });
 
-    const baselineSandwichMode = determineSandwichMode(
+    const baselineSandwichMode = determineBaselineSandwichMode(
       originalFormData.sandwichTypes,
       originalFormData.estimatedSandwichCountMin,
       originalFormData.estimatedSandwichCountMax,
@@ -345,5 +363,43 @@ describe('diff-based save clears stale range on Range -> Exact Count (500 -> 498
     expect(payload).not.toHaveProperty('estimatedSandwichCount');
     expect(payload).not.toHaveProperty('estimatedSandwichCountMin');
     expect(payload).not.toHaveProperty('estimatedSandwichCountMax');
+  });
+
+  it('heals already-corrupted rows (exact 500 + stale 490-506) on the next Exact Count save', () => {
+    // Server still has BOTH from before the client fix. UI opens Exact Count
+    // (determineSandwichMode), but the baseline must still serialize as range
+    // so the companion clears are not diffed away.
+    const original = {
+      ...baseFormData,
+      totalSandwichCount: 500,
+      estimatedSandwichCountMin: 490,
+      estimatedSandwichCountMax: 506,
+      rangeSandwichType: 'deli',
+    };
+    const current = {
+      ...baseFormData,
+      totalSandwichCount: 500,
+      estimatedSandwichCountMin: 0,
+      estimatedSandwichCountMax: 0,
+      rangeSandwichType: '',
+    };
+
+    expect(determineSandwichMode(
+      original.sandwichTypes,
+      original.estimatedSandwichCountMin,
+      original.estimatedSandwichCountMax,
+      original.totalSandwichCount,
+    )).toBe('total');
+    expect(determineBaselineSandwichMode(
+      original.sandwichTypes,
+      original.estimatedSandwichCountMin,
+      original.estimatedSandwichCountMax,
+      original.totalSandwichCount,
+    )).toBe('range');
+
+    const payload = diffSave(original, current, 'total');
+    expect(payload.estimatedSandwichCount).toBe(500);
+    expect(payload.estimatedSandwichCountMin).toBeNull();
+    expect(payload.estimatedSandwichCountMax).toBeNull();
   });
 });

--- a/client/src/components/event-requests/__tests__/mark-scheduled-save.test.ts
+++ b/client/src/components/event-requests/__tests__/mark-scheduled-save.test.ts
@@ -268,6 +268,27 @@ describe('determineSandwichMode (sandwich count drift)', () => {
     expect(payload.estimatedSandwichCountMax).toBeNull();
     expect(payload.estimatedSandwichRangeType).toBeNull();
   });
+
+  it('includes cancelledReason when status is cancelled (edit-form MISSING_REASON bug)', () => {
+    const payload = buildEventDataForServer(
+      {
+        ...baseFormData,
+        status: 'cancelled',
+        cancelledReason: 'Organizer cancelled',
+        cancelledNotes: 'Venue fell through',
+      },
+      {
+        mode: 'edit',
+        hasEventRequest: true,
+        eventRequestStatus: 'scheduled',
+        sandwichMode: 'total',
+        actualSandwichMode: 'total',
+      },
+    );
+    expect(payload.status).toBe('cancelled');
+    expect(payload.cancelledReason).toBe('Organizer cancelled');
+    expect(payload.cancelledNotes).toBe('Venue fell through');
+  });
 });
 
 /**

--- a/client/src/components/event-requests/cards/CompletedCard.tsx
+++ b/client/src/components/event-requests/cards/CompletedCard.tsx
@@ -39,6 +39,7 @@ import {
 import { formatTime12Hour, formatEventDate } from '@/components/event-requests/utils';
 import { useEventQueries } from '../hooks/useEventQueries';
 import { formatSandwichTypesDisplay, parseSandwichTypes } from '@/lib/sandwich-utils';
+import { hasActiveSandwichRange } from '@shared/sandwich-count-utils';
 import { getDisplayName } from '@/lib/userHelpers';
 import { extractNameFromCustomId } from '@/lib/utils';
 import { ConfirmationDialog } from '@/components/ui/confirmation-dialog';
@@ -2515,7 +2516,11 @@ export const CompletedCard: React.FC<CompletedCardProps> = ({
                 <span className="text-gray-700">
                   Planned <strong className="font-semibold">
                     {(() => {
-                      const hasRange = request.estimatedSandwichCountMin && request.estimatedSandwichCountMax;
+                      const hasRange = hasActiveSandwichRange(
+                        request.estimatedSandwichCountMin,
+                        request.estimatedSandwichCountMax,
+                        request.estimatedSandwichCount,
+                      );
                       if (hasRange) {
                         const rangeType = (request as any).estimatedSandwichRangeType;
                         const typeLabel = rangeType ? SANDWICH_TYPES.find(t => t.value === rangeType)?.label : null;

--- a/client/src/components/event-requests/cards/ScheduledCardEnhanced.tsx
+++ b/client/src/components/event-requests/cards/ScheduledCardEnhanced.tsx
@@ -68,6 +68,7 @@ import {
   parseSandwichTypes,
   formatSandwichTypesDisplay,
 } from '@/lib/sandwich-utils';
+import { hasActiveSandwichRange } from '@shared/sandwich-count-utils';
 import {
   extractNameFromAssignmentId,
   resolveAssignmentDisplayName,
@@ -516,8 +517,13 @@ export const ScheduledCardEnhanced: React.FC<ScheduledCardEnhancedProps> = ({
     ? 'bg-[#A31C41] text-white border border-[#A31C41]'
     : 'bg-amber-50 text-amber-800 border border-amber-400';
 
-  // Sandwich info
-  const hasRange = request.estimatedSandwichCountMin && request.estimatedSandwichCountMax;
+  // Sandwich info — ignore a leftover range whose midpoint disagrees with the
+  // exact count (stale range after Exact Count save → "500 shows as 498").
+  const hasRange = hasActiveSandwichRange(
+    request.estimatedSandwichCountMin,
+    request.estimatedSandwichCountMax,
+    request.estimatedSandwichCount,
+  );
   let sandwichInfo;
   if (hasRange) {
     const rangeType = request.estimatedSandwichRangeType;

--- a/client/src/components/event-requests/cards/ScheduledCardEnhanced.tsx
+++ b/client/src/components/event-requests/cards/ScheduledCardEnhanced.tsx
@@ -108,7 +108,7 @@ import { Flag } from 'lucide-react';
 import { ProposeToSheetButton } from '@/components/propose-to-sheet-button';
 import { InlineRecipientAllocationEditor } from '../InlineRecipientAllocationEditor';
 import { useReturningOrganization } from '@/hooks/use-returning-organization';
-import { RefreshCw, Copy } from 'lucide-react';
+import { RefreshCw, Copy, Ban } from 'lucide-react';
 import type { RecipientAllocation } from '../RecipientAllocationEditor';
 import { getEffectiveEventDate } from '@shared/event-validation-utils';
 import { isScheduledOrRescheduled } from '@shared/event-status-workflow';
@@ -133,6 +133,7 @@ interface ScheduledCardEnhancedProps {
   onEditTspContact: () => void;
   onLogContact: () => void;
   onReschedule: () => void;
+  onCancelEvent?: () => void;
   onDuplicate?: () => void;
   onAiIntakeAssist?: () => void;
   startEditing: (field: string, value: string) => void;
@@ -197,6 +198,7 @@ export const ScheduledCardEnhanced: React.FC<ScheduledCardEnhancedProps> = ({
   onEditTspContact,
   onLogContact,
   onReschedule,
+  onCancelEvent,
   onDuplicate,
   onAiIntakeAssist,
   startEditing,
@@ -4125,6 +4127,26 @@ export const ScheduledCardEnhanced: React.FC<ScheduledCardEnhancedProps> = ({
             <Button size="sm" variant="outline" onClick={onReschedule}>
               Reschedule
             </Button>
+
+            {onCancelEvent && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={onCancelEvent}
+                    className="border-red-400 text-red-600 hover:bg-red-50"
+                    data-testid="button-cancel-event"
+                  >
+                    <Ban className="w-4 h-4 mr-1" />
+                    Cancel Event
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Cancel this scheduled event (requires a reason)</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
 
             {onDuplicate && (
               <Button size="sm" variant="outline" onClick={onDuplicate}>

--- a/client/src/components/event-requests/form-sections/types.ts
+++ b/client/src/components/event-requests/form-sections/types.ts
@@ -98,6 +98,12 @@ export interface EventFormData {
   volunteerInstructions: string;
   // Standby follow-up
   standbyExpectedDate: string;
+  // Reason fields for cancelled / declined (filled by StatusReasonDialog
+  // when the status dropdown is used in the edit form)
+  cancelledReason: string;
+  cancelledNotes: string;
+  declinedReason: string;
+  declinedNotes: string;
 }
 
 /**

--- a/client/src/components/event-requests/form-utils.ts
+++ b/client/src/components/event-requests/form-utils.ts
@@ -7,6 +7,7 @@
  * 3. Simplify the performSubmit function
  */
 
+import { hasActiveSandwichRange } from '@shared/sandwich-count-utils';
 import type { EventFormData } from './form-sections/types';
 export { findMismatchedSavedFields, getDroppedServerFields } from '@/lib/event-save-verification';
 
@@ -169,9 +170,8 @@ export function buildEventDataForServer(
   // Sandwich data based on mode.
   // Each mode owns exactly one representation of the count; the OTHER two
   // representations must be explicitly nulled so a stale range/breakdown can't
-  // survive in the DB and get preferred over the exact count by
-  // getReportableSandwichCount (which resolves range midpoint BEFORE
-  // estimatedSandwichCount). See the diff-based save note in EventSchedulingForm.
+  // survive in the DB alongside an exact count (the "500 shows as 498" bug).
+  // See the diff-based save note in EventSchedulingForm.
   if (sandwichMode === 'total') {
     eventData.estimatedSandwichCount = formData.totalSandwichCount;
     eventData.sandwichTypes = null;
@@ -253,6 +253,9 @@ export function sumSandwichTypeQuantities(sandwichTypes: unknown): number {
  * When estimatedSandwichCount disagrees with a stale sandwichTypes breakdown,
  * prefer Exact Count so a full-form save does not silently revert the total
  * (e.g. user enters 200 but old types still sum to 198).
+ *
+ * Same rule for a leftover range whose midpoint disagrees with the exact count
+ * (e.g. exact 500 + stale 490-506 → midpoint 498): open Exact Count, not Range.
  */
 export function determineSandwichMode(
   sandwichTypes: any,
@@ -260,8 +263,15 @@ export function determineSandwichMode(
   estimatedSandwichCountMax: any,
   estimatedSandwichCount?: number | null,
 ): 'total' | 'range' | 'types' {
-  const hasRangeData = estimatedSandwichCountMin && estimatedSandwichCountMax;
-  if (hasRangeData) return 'range';
+  if (
+    hasActiveSandwichRange(
+      estimatedSandwichCountMin,
+      estimatedSandwichCountMax,
+      estimatedSandwichCount,
+    )
+  ) {
+    return 'range';
+  }
 
   let parsed: unknown[] = [];
   try {
@@ -287,6 +297,31 @@ export function determineSandwichMode(
   }
 
   return 'types';
+}
+
+/**
+ * Mode for diff-baseline serialization of what is PHYSICALLY stored.
+ *
+ * Unlike determineSandwichMode (UI), any persisted min/max counts as 'range'
+ * even when a disagreeing exact count means the range is stale. That way a
+ * subsequent Exact Count save still detects min/max → null as a real change
+ * and clears the leftover range instead of dropping the clears (null === null).
+ */
+export function determineBaselineSandwichMode(
+  sandwichTypes: any,
+  estimatedSandwichCountMin: any,
+  estimatedSandwichCountMax: any,
+  estimatedSandwichCount?: number | null,
+): 'total' | 'range' | 'types' {
+  if (estimatedSandwichCountMin && estimatedSandwichCountMax) {
+    return 'range';
+  }
+  return determineSandwichMode(
+    sandwichTypes,
+    estimatedSandwichCountMin,
+    estimatedSandwichCountMax,
+    estimatedSandwichCount,
+  );
 }
 
 /**

--- a/client/src/components/event-requests/form-utils.ts
+++ b/client/src/components/event-requests/form-utils.ts
@@ -110,6 +110,23 @@ export function buildEventDataForServer(
     driverInstructions: formData.driverInstructions || null,
     volunteerInstructions: formData.volunteerInstructions || null,
 
+    // Structured reason fields — required by the server when status becomes
+    // cancelled/declined. The card Cancel/Decline dialogs set these directly;
+    // the edit-form status dropdown captures them via StatusReasonDialog and
+    // stashes them on formData before save.
+    ...(resolvedStatus === 'cancelled'
+      ? {
+          cancelledReason: (formData as any).cancelledReason || null,
+          cancelledNotes: (formData as any).cancelledNotes || null,
+        }
+      : {}),
+    ...(resolvedStatus === 'declined'
+      ? {
+          declinedReason: (formData as any).declinedReason || null,
+          declinedNotes: (formData as any).declinedNotes || null,
+        }
+      : {}),
+
     // Manual entry
     manualEntrySource: formData.manualEntrySource || null,
 

--- a/client/src/components/event-requests/tabs/MyAssignmentsTab.tsx
+++ b/client/src/components/event-requests/tabs/MyAssignmentsTab.tsx
@@ -321,6 +321,13 @@ export const MyAssignmentsTab: React.FC = () => {
             onReschedule={() => {
               // Handle reschedule if needed
             }}
+            onCancelEvent={async () => {
+              const result = await handleStatusChange(request.id, 'cancelled');
+              if (result === 'needs_reason') {
+                setReasonDialogEventRequest(request);
+                openDialog('cancel');
+              }
+            }}
             onAssignTspContact={() => {
               setTspContactEventRequest(request);
               openDialog('tspContactAssignment');

--- a/client/src/components/event-requests/tabs/ScheduledTab.tsx
+++ b/client/src/components/event-requests/tabs/ScheduledTab.tsx
@@ -103,6 +103,7 @@ export const ScheduledTab: React.FC = () => {
     setAiIntakeAssistantEventRequest,
     setNextActionEventRequest,
     setNextActionMode,
+    setReasonDialogEventRequest,
     editingScheduledId,
     setEditingScheduledId,
     editingField,
@@ -541,6 +542,13 @@ export const ScheduledTab: React.FC = () => {
                 onReschedule={() => {
                   setRescheduleRequest(request);
                   setShowRescheduleDialog(true);
+                }}
+                onCancelEvent={async () => {
+                  const result = await handleStatusChange(request.id, 'cancelled');
+                  if (result === 'needs_reason') {
+                    setReasonDialogEventRequest(request);
+                    openDialog('cancel');
+                  }
                 }}
                 onDuplicate={() => {
                   setDuplicateSourceRequest(request);

--- a/client/src/components/event-requests/tabs/ScheduledTab.tsx
+++ b/client/src/components/event-requests/tabs/ScheduledTab.tsx
@@ -11,6 +11,7 @@ import { ScheduledCardEnhanced } from '../cards/ScheduledCardEnhanced';
 import { RescheduleDialog } from '../dialogs/RescheduleDialog';
 import { DuplicateEventDialog } from '../dialogs/DuplicateEventDialog';
 import { parseSandwichTypes, stringifySandwichTypes } from '@/lib/sandwich-utils';
+import { hasActiveSandwichRange } from '@shared/sandwich-count-utils';
 import { useConfirmation } from '@/components/ui/confirmation-dialog';
 import type { EventRequest } from '@shared/schema';
 import { ScheduledSpreadsheetView } from '../views/ScheduledSpreadsheetView';
@@ -156,7 +157,11 @@ export const ScheduledTab: React.FC = () => {
       if (eventRequest) {
         const existingSandwichTypes = parseSandwichTypes(eventRequest.sandwichTypes) || [];
         const hasTypesData = existingSandwichTypes.length > 0;
-        const hasRangeData = (eventRequest as any).estimatedSandwichCountMin && (eventRequest as any).estimatedSandwichCountMax;
+        const hasRangeData = hasActiveSandwichRange(
+          (eventRequest as any).estimatedSandwichCountMin,
+          (eventRequest as any).estimatedSandwichCountMax,
+          eventRequest.estimatedSandwichCount,
+        );
         const totalCount = eventRequest.estimatedSandwichCount || 0;
 
         setInlineSandwichMode(hasTypesData ? 'types' : hasRangeData ? 'range' : 'total');

--- a/client/src/components/event-requests/views/ScheduledSpreadsheetView.tsx
+++ b/client/src/components/event-requests/views/ScheduledSpreadsheetView.tsx
@@ -62,6 +62,7 @@ import {
 import { format } from 'date-fns';
 import type { EventRequest } from '@shared/schema';
 import { parseSandwichTypes } from '@/lib/sandwich-utils';
+import { hasActiveSandwichRange } from '@shared/sandwich-count-utils';
 import {
   getDriverIds, getDriverCount, getTotalDriverCount,
   getVolunteerIds, getVolunteerCount
@@ -1515,7 +1516,7 @@ export const ScheduledSpreadsheetView: React.FC<ScheduledSpreadsheetViewProps> =
         const count = event.estimatedSandwichCount;
         const min = event.estimatedSandwichCountMin;
         const max = event.estimatedSandwichCountMax;
-        if (min && max) return `${min}-${max}`;
+        if (hasActiveSandwichRange(min, max, count)) return `${min}-${max}`;
         return count?.toString() || '';
       },
     },

--- a/shared/sandwich-count-utils.ts
+++ b/shared/sandwich-count-utils.ts
@@ -69,6 +69,28 @@ export function getRangeMidpoint(minValue: number | string | null | undefined, m
   return min ?? max;
 }
 
+/**
+ * True when min/max should drive UI/reporting as an active range.
+ *
+ * Returns false when an exact estimatedSandwichCount is present AND disagrees
+ * with the range midpoint — that signature is the "500 saves as 498" bug:
+ * a leftover range whose midpoint overrides the exact count the user entered.
+ * Legitimate imports store count === midpoint and stay treated as a range.
+ */
+export function hasActiveSandwichRange(
+  estimatedSandwichCountMin: number | string | null | undefined,
+  estimatedSandwichCountMax: number | string | null | undefined,
+  estimatedSandwichCount?: number | string | null,
+): boolean {
+  const midpoint = getRangeMidpoint(estimatedSandwichCountMin, estimatedSandwichCountMax);
+  if (midpoint === null) return false;
+
+  const exact = toFiniteCount(estimatedSandwichCount);
+  if (exact !== null && exact !== midpoint) return false;
+
+  return true;
+}
+
 export function getReportableSandwichCount(
   event: SandwichCountFields,
   options: ReportableSandwichCountOptions = {},
@@ -76,18 +98,23 @@ export function getReportableSandwichCount(
   const actualCount = toFiniteCount(event.actualSandwichCount);
   if (actualCount !== null) return actualCount;
 
+  // Prefer an explicit exact count over a range midpoint. Clean range-mode
+  // saves null estimatedSandwichCount, so they still fall through to the
+  // midpoint. Corrupted rows that keep BOTH (exact 500 + stale 490-506 →
+  // midpoint 498) must show what the user typed, not the leftover range.
+  const estimatedCount = toFiniteCount(event.estimatedSandwichCount);
+  if (estimatedCount !== null) {
+    if (
+      options.ignoreSuspiciousEstimatedCounts &&
+      estimatedCount >= (options.suspiciousEstimatedThreshold ?? 50000)
+    ) {
+      return 0;
+    }
+    return estimatedCount;
+  }
+
   const rangeMidpoint = getRangeMidpoint(event.estimatedSandwichCountMin, event.estimatedSandwichCountMax);
   if (rangeMidpoint !== null) return rangeMidpoint;
 
-  const estimatedCount = toFiniteCount(event.estimatedSandwichCount);
-  if (estimatedCount === null) return 0;
-
-  if (
-    options.ignoreSuspiciousEstimatedCounts &&
-    estimatedCount >= (options.suspiciousEstimatedThreshold ?? 50000)
-  ) {
-    return 0;
-  }
-
-  return estimatedCount;
+  return 0;
 }

--- a/tests/unit/sandwich-count-utils.test.ts
+++ b/tests/unit/sandwich-count-utils.test.ts
@@ -1,0 +1,72 @@
+import {
+  getReportableSandwichCount,
+  hasActiveSandwichRange,
+  getRangeMidpoint,
+} from '../../shared/sandwich-count-utils';
+
+describe('getRangeMidpoint', () => {
+  it('rounds the midpoint of a range (490-506 → 498)', () => {
+    expect(getRangeMidpoint(490, 506)).toBe(498);
+  });
+});
+
+describe('hasActiveSandwichRange', () => {
+  it('is false when exact count disagrees with range midpoint (stale range)', () => {
+    expect(hasActiveSandwichRange(490, 506, 500)).toBe(false);
+  });
+
+  it('is true when exact equals midpoint (imported range)', () => {
+    expect(hasActiveSandwichRange(490, 506, 498)).toBe(true);
+  });
+
+  it('is true for a pure range with no exact count', () => {
+    expect(hasActiveSandwichRange(490, 506, null)).toBe(true);
+  });
+
+  it('is false when there is no range', () => {
+    expect(hasActiveSandwichRange(null, null, 500)).toBe(false);
+  });
+});
+
+describe('getReportableSandwichCount (500 vs 498)', () => {
+  it('prefers the exact count over a stale range midpoint', () => {
+    expect(
+      getReportableSandwichCount({
+        estimatedSandwichCount: 500,
+        estimatedSandwichCountMin: 490,
+        estimatedSandwichCountMax: 506,
+      }),
+    ).toBe(500);
+  });
+
+  it('uses the range midpoint when there is no exact count', () => {
+    expect(
+      getReportableSandwichCount({
+        estimatedSandwichCount: null,
+        estimatedSandwichCountMin: 490,
+        estimatedSandwichCountMax: 506,
+      }),
+    ).toBe(498);
+  });
+
+  it('uses the exact count when there is no range', () => {
+    expect(
+      getReportableSandwichCount({
+        estimatedSandwichCount: 500,
+        estimatedSandwichCountMin: null,
+        estimatedSandwichCountMax: null,
+      }),
+    ).toBe(500);
+  });
+
+  it('prefers actual count over everything', () => {
+    expect(
+      getReportableSandwichCount({
+        actualSandwichCount: 512,
+        estimatedSandwichCount: 500,
+        estimatedSandwichCountMin: 490,
+        estimatedSandwichCountMax: 506,
+      }),
+    ).toBe(512);
+  });
+});


### PR DESCRIPTION
## Summary
- Stop exact sandwich estimates (e.g. 500) from displaying as a stale range midpoint (e.g. 498) by preferring exact counts and clearing leftover min/max on save.
- Add a **Cancel Event** action on scheduled cards that opens the existing reason dialog.
- When Cancelled/Declined is chosen in the edit-form status dropdown, prompt for a reason and include it on save so `MISSING_REASON` (400) no longer blocks form saves (e.g. Susan's Baldwin Group report).

## Test plan
- [ ] Edit an event that previously had a sandwich range; set Exact Count to 500, save, confirm the card/list still shows 500 (not a midpoint like 498)
- [ ] On a scheduled card, click **Cancel Event**, enter a reason, confirm it moves to cancelled
- [ ] Open Edit on a scheduled event, change status dropdown to Cancelled, enter reason in the dialog, Save — should succeed without `MISSING_REASON`
- [ ] Same dropdown path for Declined
- [ ] Pure range events (no exact count) still display as a range


Made with [Cursor](https://cursor.com)