### PR TITLE
Tighten sandwich range detection and typed cancel reasons

### DIFF
--- a/client/src/components/event-requests/form-utils.ts
+++ b/client/src/components/event-requests/form-utils.ts
@@ -116,14 +116,14 @@ export function buildEventDataForServer(
     // stashes them on formData before save.
     ...(resolvedStatus === 'cancelled'
       ? {
-          cancelledReason: (formData as any).cancelledReason || null,
-          cancelledNotes: (formData as any).cancelledNotes || null,
+          cancelledReason: formData.cancelledReason || null,
+          cancelledNotes: formData.cancelledNotes || null,
         }
       : {}),
     ...(resolvedStatus === 'declined'
       ? {
-          declinedReason: (formData as any).declinedReason || null,
-          declinedNotes: (formData as any).declinedNotes || null,
+          declinedReason: formData.declinedReason || null,
+          declinedNotes: formData.declinedNotes || null,
         }
       : {}),
 

--- a/shared/sandwich-count-utils.ts
+++ b/shared/sandwich-count-utils.ts
@@ -70,25 +70,27 @@ export function getRangeMidpoint(minValue: number | string | null | undefined, m
 }
 
 /**
- * True when min/max should drive UI/reporting as an active range.
+ * True when min/max should drive UI as a complete active range.
  *
- * Returns false when an exact estimatedSandwichCount is present AND disagrees
- * with the range midpoint — that signature is the "500 saves as 498" bug:
- * a leftover range whose midpoint overrides the exact count the user entered.
- * Legitimate imports store count === midpoint and stay treated as a range.
+ * Requires BOTH bounds so call sites can safely render `${min}-${max}` without
+ * producing strings like "490-null". Also returns false when an exact
+ * estimatedSandwichCount is present AND disagrees with the range midpoint —
+ * that signature is the "500 saves as 498" bug (a leftover range whose
+ * midpoint overrides the exact count the user entered). Legitimate imports
+ * store count === midpoint and stay treated as a range.
  */
 export function hasActiveSandwichRange(
   estimatedSandwichCountMin: number | string | null | undefined,
   estimatedSandwichCountMax: number | string | null | undefined,
   estimatedSandwichCount?: number | string | null,
 ): boolean {
-  const midpoint = getRangeMidpoint(estimatedSandwichCountMin, estimatedSandwichCountMax);
-  if (midpoint === null) return false;
+  const min = toFiniteCount(estimatedSandwichCountMin);
+  const max = toFiniteCount(estimatedSandwichCountMax);
+  if (min === null || max === null) return false;
 
+  const midpoint = Math.round((Math.min(min, max) + Math.max(min, max)) / 2);
   const exact = toFiniteCount(estimatedSandwichCount);
-  if (exact !== null && exact !== midpoint) return false;
-
-  return true;
+  return exact === null || exact === midpoint;
 }
 
 export function getReportableSandwichCount(

--- a/tests/unit/sandwich-count-utils.test.ts
+++ b/tests/unit/sandwich-count-utils.test.ts
@@ -26,6 +26,11 @@ describe('hasActiveSandwichRange', () => {
   it('is false when there is no range', () => {
     expect(hasActiveSandwichRange(null, null, 500)).toBe(false);
   });
+
+  it('is false when only one bound is present (incomplete range)', () => {
+    expect(hasActiveSandwichRange(490, null, null)).toBe(false);
+    expect(hasActiveSandwichRange(null, 506, null)).toBe(false);
+  });
 });
 
 describe('getReportableSandwichCount (500 vs 498)', () => {


### PR DESCRIPTION
## Summary
- Require both min and max sandwich bounds in `hasActiveSandwichRange` so partial ranges can't render as `490-null` / `null-506`.
- Drop `as any` when writing cancelled/declined reason fields from `EventFormData`.
- Add a regression test for incomplete ranges.

Follow-up to Copilot review on #477.

## Test plan
- [ ] Event with only `estimatedSandwichCountMin` (no max) shows exact count / TBD, not a broken `min-null` range string
- [ ] Full ranges (e.g. 490–506) still display as a range when exact equals midpoint or is absent
- [ ] Cancel/decline from edit form still saves reason fields correctly


Made with [Cursor](https://cursor.com)