### PR TITLE
Neutralize CSV formula injection in Groups Catalog export.

### DIFF
--- a/client/src/components/organizations-catalog.tsx
+++ b/client/src/components/organizations-catalog.tsx
@@ -743,7 +743,11 @@ export default function GroupCatalog({
   };
 
   const escapeCsvCell = (value: unknown): string => {
-    const str = String(value ?? '');
+    let str = String(value ?? '');
+    // Neutralize spreadsheet formula injection (=, +, -, @, tab, CR)
+    if (/^[=+\-@\t\r]/.test(str)) {
+      str = `'${str}`;
+    }
     return `"${str.replace(/"/g, '""')}"`;
   };
 


### PR DESCRIPTION
Prefix cells starting with =, +, -, @, tab, or CR so spreadsheets do not execute them as formulas.