### PR TITLE
Fix slow event create and dashboard widget loading

### DIFF
--- a/client/src/components/event-requests/EventSchedulingForm.tsx
+++ b/client/src/components/event-requests/EventSchedulingForm.tsx
@@ -863,13 +863,16 @@ const EventSchedulingForm: React.FC<EventSchedulingFormProps> = ({
   const createEventRequestMutation = useMutation({
     mutationFn: (data: any) => apiRequest('POST', '/api/event-requests', data),
     networkMode: 'always',
-    onSuccess: async () => {
+    onSuccess: () => {
       clearAutoSave();
       setHasRecoveredData(false);
       toast({ title: 'Event Created Successfully', description: `"${formData.organizationName || 'New event'}" has been created.`, duration: 8000 });
-      await invalidateEventRequestQueries(queryClient);
+      // Close immediately — the event is already saved. List refresh must not
+      // keep the dialog stuck on "Creating..." (users were canceling mid-wait
+      // and then finding the event had already been created).
       onSuccessCallback();
       onClose();
+      void refreshEventRequestListAndCounts(queryClient);
     },
     onError: (error: any) => {
       setIsSubmitting(false);

--- a/client/src/components/event-requests/hooks/useEventMutations.tsx
+++ b/client/src/components/event-requests/hooks/useEventMutations.tsx
@@ -229,7 +229,7 @@ export const useEventMutations = () => {
       logger.log('Response:', result);
       return result;
     },
-    onSuccess: async (data) => {
+    onSuccess: (data) => {
       logger.log('=== CREATE EVENT SUCCESS HANDLER ===');
       logger.log('Created event:', data);
 
@@ -240,12 +240,13 @@ export const useEventMutations = () => {
         duration: 8000,
       });
 
-      // Await query invalidation so the list reflects the new event
-      await invalidateEventRequestQueries(queryClient);
-
+      // Close immediately — the event is already saved. Refresh lists in the
+      // background so the dialog doesn't sit on "Creating..." while every
+      // event/volunteer-hub query refetches.
       closeDialog('eventDetails');
       setSelectedEventRequest(null);
       setIsEditing(false);
+      void refreshEventRequestListAndCounts(queryClient);
     },
     onError: (error: any) => {
       logger.error('Create event request error:', error);

--- a/client/src/components/low-volume-alert.tsx
+++ b/client/src/components/low-volume-alert.tsx
@@ -105,9 +105,19 @@ function formatWeekRange(start: Date, end: Date): string {
 }
 
 export function LowVolumeAlert({ onNavigateToWeek }: LowVolumeAlertProps) {
-  // Fetch event requests
+  // Active upcoming pipeline only — the unfiltered `/api/event-requests` table
+  // is far larger than this forecast needs and was starving the dashboard.
   const { data: eventRequests = [] } = useQuery<EventRequest[]>({
-    queryKey: ['/api/event-requests'],
+    queryKey: ['/api/event-requests/list', { status: 'scheduled,in_process,rescheduled' }, 'group-forecast'],
+    queryFn: async ({ signal }) => {
+      const response = await fetch(
+        '/api/event-requests/list?status=scheduled,in_process,rescheduled',
+        { credentials: 'include', signal },
+      );
+      if (!response.ok) throw new Error('Failed to fetch event requests');
+      const data = await response.json();
+      return Array.isArray(data) ? data : [];
+    },
   });
 
   // Fetch historical collection data to calculate baseline and current week actuals

--- a/client/src/components/operational-overview.tsx
+++ b/client/src/components/operational-overview.tsx
@@ -879,8 +879,31 @@ function MyAssignmentsView({
 }
 
 export default function OperationalOverview({ onNavigate }: OperationalOverviewProps) {
-  const { data: stats, isLoading, error } = useQuery<OperationalStats>({
+  const { data: stats, isLoading, isError, error, refetch } = useQuery<OperationalStats | null>({
     queryKey: ['/api/event-requests/operational-stats'],
+    queryFn: async ({ signal }) => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 25000);
+      const onAbort = () => controller.abort();
+      signal?.addEventListener('abort', onAbort);
+      try {
+        const res = await fetch('/api/event-requests/operational-stats', {
+          credentials: 'include',
+          signal: controller.signal,
+        });
+        if (res.status === 403 || res.status === 401) {
+          // No permission / not logged in — hide the widget quietly.
+          return null;
+        }
+        if (!res.ok) {
+          throw new Error('Failed to load operational stats');
+        }
+        return (await res.json()) as OperationalStats;
+      } finally {
+        clearTimeout(timeoutId);
+        signal?.removeEventListener('abort', onAbort);
+      }
+    },
     staleTime: 60 * 1000, // 1 minute
     refetchInterval: 2 * 60 * 1000, // Refresh every 2 minutes
   });
@@ -912,10 +935,6 @@ export default function OperationalOverview({ onNavigate }: OperationalOverviewP
     onNavigate('event-requests');
   };
 
-  if (error) {
-    return null; // Silently fail if user doesn't have permission
-  }
-
   if (isLoading) {
     return (
       <div className="mx-4 mb-8">
@@ -924,8 +943,39 @@ export default function OperationalOverview({ onNavigate }: OperationalOverviewP
     );
   }
 
-  if (!stats) {
+  // Permission-denied path returns null data without throwing.
+  if (!stats && !isError) {
     return null;
+  }
+
+  if (isError || !stats) {
+    return (
+      <div className="mx-4 mb-8">
+        <div
+          className="premium-card-elevated p-6"
+          style={{ borderTop: '4px solid #007E8C' }}
+        >
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+            <div>
+              <h3 className="premium-text-h4 text-brand-primary">My Assignments</h3>
+              <p className="premium-text-body-sm text-gray-600 mt-1">
+                Couldn't load your assigned events right now.
+                {error instanceof Error && error.name === 'AbortError'
+                  ? ' The request timed out.'
+                  : ''}
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => refetch()}
+              className="border-brand-primary text-brand-primary hover:bg-brand-primary hover:text-white"
+            >
+              Try again
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   // Personalized snapshot takes priority for users with TSP-contact

--- a/client/src/components/volunteer-opportunities-spotlight.tsx
+++ b/client/src/components/volunteer-opportunities-spotlight.tsx
@@ -68,13 +68,28 @@ const getUrgency = (request: EventRequest): Urgency => {
 };
 
 export function VolunteerOpportunitiesSpotlight({ onNavigate }: VolunteerOpportunitiesSpotlightProps) {
-  const { data: eventRequests = [], isLoading } = useQuery<EventRequest[]>({
-    queryKey: ['/api/event-requests'],
+  // Only scheduled/rescheduled rows — never the full event-requests table.
+  // The unfiltered `/api/event-requests` payload is large enough to leave this
+  // widget stuck on its skeleton while the dashboard's other sections render.
+  const { data: eventRequests = [], isLoading, isError, refetch } = useQuery<EventRequest[]>({
+    queryKey: ['/api/event-requests/list', { status: 'scheduled,rescheduled' }, 'volunteer-spotlight'],
+    queryFn: async ({ signal }) => {
+      const response = await fetch(
+        '/api/event-requests/list?status=scheduled,rescheduled',
+        { credentials: 'include', signal },
+      );
+      if (!response.ok) {
+        throw new Error('Failed to fetch volunteer opportunities');
+      }
+      const data = await response.json();
+      return Array.isArray(data) ? data : [];
+    },
     staleTime: 60 * 1000,
   });
 
-  const opportunities = eventRequests
+  const understaffedUpcoming = (Array.isArray(eventRequests) ? eventRequests : [])
     .filter((request) => isScheduledOrRescheduled(request.status))
+    .filter((request) => daysUntil(request) >= 0)
     .filter((request) => {
       const { needsVolunteer, needsDriver } = getUnfilledNeeds(request);
       return needsVolunteer || needsDriver;
@@ -85,8 +100,9 @@ export function VolunteerOpportunitiesSpotlight({ onNavigate }: VolunteerOpportu
       const timeA = dateA ? (parseDateOnly(dateA)?.getTime() ?? Infinity) : Infinity;
       const timeB = dateB ? (parseDateOnly(dateB)?.getTime() ?? Infinity) : Infinity;
       return timeA - timeB;
-    })
-    .slice(0, 3);
+    });
+
+  const opportunities = understaffedUpcoming.slice(0, 3);
 
   const formatEventDate = (request: EventRequest) => {
     const date = getEffectiveEventDate(request);
@@ -100,6 +116,28 @@ export function VolunteerOpportunitiesSpotlight({ onNavigate }: VolunteerOpportu
         <div className="space-y-3">
           <div className="h-20 bg-gray-100 rounded"></div>
           <div className="h-20 bg-gray-100 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="premium-card-elevated p-6 mx-4 mb-8" style={{ borderTop: '4px solid #007E8C' }}>
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+          <div>
+            <h3 className="premium-text-h4 text-[#007E8C]">Volunteer Opportunities</h3>
+            <p className="premium-text-body-sm text-gray-600 mt-1">
+              Couldn't load volunteer needs right now.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="premium-btn-outline text-sm"
+          >
+            Try again
+          </button>
         </div>
       </div>
     );
@@ -208,9 +246,9 @@ export function VolunteerOpportunitiesSpotlight({ onNavigate }: VolunteerOpportu
 
       <div className="mt-4 pt-4 border-t border-gray-100 flex items-center justify-between">
         <p className="text-sm text-gray-500">
-          {opportunities.length < eventRequests.filter(r => isScheduledOrRescheduled(r.status) && (getUnfilledNeeds(r).needsVolunteer || getUnfilledNeeds(r).needsDriver)).length
-            ? `Showing ${opportunities.length} of ${eventRequests.filter(r => isScheduledOrRescheduled(r.status) && (getUnfilledNeeds(r).needsVolunteer || getUnfilledNeeds(r).needsDriver)).length} opportunities`
-            : `${opportunities.length} upcoming opportunity${opportunities.length !== 1 ? 'ies' : 'y'}`}
+          {opportunities.length < understaffedUpcoming.length
+            ? `Showing ${opportunities.length} of ${understaffedUpcoming.length} opportunities`
+            : `${opportunities.length} upcoming opportunit${opportunities.length !== 1 ? 'ies' : 'y'}`}
         </p>
         <button
           onClick={() => onNavigate('event-requests')}

--- a/server/routes/event-requests-legacy.ts
+++ b/server/routes/event-requests-legacy.ts
@@ -1860,24 +1860,6 @@ router.post(
         createdBy: user?.id || 1,
       });
 
-      // Geocode address synchronously so coordinates are set before response
-      if (validatedData.eventAddress) {
-        try {
-          const coords = await geocodeAddress(validatedData.eventAddress);
-          if (coords) {
-            await storage.updateEventRequest(newEventRequest.id!, {
-              latitude: coords.latitude,
-              longitude: coords.longitude,
-            });
-            logger.log(`✅ Geocoded event ${newEventRequest.id}: ${validatedData.eventAddress}`);
-          } else {
-            logger.warn(`⚠️ Geocoding returned no results for event ${newEventRequest.id}: ${validatedData.eventAddress}`);
-          }
-        } catch (error) {
-          logger.error(`Failed to geocode event ${newEventRequest.id}:`, error);
-        }
-      }
-
       // Enhanced audit logging for create operation
       await AuditLogger.logEventRequestChange(
         newEventRequest.id?.toString() || 'unknown',
@@ -1898,6 +1880,29 @@ router.post(
         'EVENT_REQUESTS_ADD',
         `Created event request: ${newEventRequest.id} for ${validatedData.organizationName}`
       );
+
+      // Geocode asynchronously — don't block the create response on Google/OSM.
+      // Coordinates appear shortly after; map views can pick them up on refresh.
+      if (validatedData.eventAddress) {
+        const eventId = newEventRequest.id!;
+        const address = validatedData.eventAddress;
+        geocodeAddress(address)
+          .then(async (coords) => {
+            if (coords) {
+              await storage.updateEventRequest(eventId, {
+                latitude: coords.latitude,
+                longitude: coords.longitude,
+              });
+              logger.log(`✅ Geocoded event ${eventId}: ${address}`);
+            } else {
+              logger.warn(`⚠️ Geocoding returned no results for event ${eventId}: ${address}`);
+            }
+          })
+          .catch((error) => {
+            logger.error(`Failed to geocode event ${eventId}:`, error);
+          });
+      }
+
       res.status(201).json(newEventRequest);
     } catch (error) {
       if (error instanceof z.ZodError) {

--- a/server/routes/event-requests-legacy.ts
+++ b/server/routes/event-requests-legacy.ts
@@ -23,7 +23,7 @@ import { isAuthenticated } from '../auth';
 import { getEventRequestsGoogleSheetsService } from '../google-sheets-event-requests-sync';
 import { AuditLogger } from '../audit-logger';
 import { db } from '../db';
-import { eq, desc, and, sql, gte, or, isNull, ne, isNotNull } from 'drizzle-orm';
+import { eq, desc, and, sql, gte, lte, or, isNull, ne, isNotNull } from 'drizzle-orm';
 import { EmailNotificationService } from '../services/email-notification-service';
 import { logger } from '../middleware/logger';
 import type { AuthenticatedRequest } from '../types/express';
@@ -4996,7 +4996,10 @@ router.get(
   requirePermission('EVENT_REQUESTS_VIEW'),
   async (req, res) => {
     try {
-      const allEventRequests = await storage.getAllEventRequests();
+      // Active statuses only — never load the full event_requests table (completed
+      // history alone is large enough to leave the dashboard Today widget spinning).
+      const activeStatuses = ['new', 'in_process', 'scheduled', 'rescheduled'];
+      const activeEvents = await storage.getEventRequestsByStatuses(activeStatuses);
 
       // Use timezone-safe date handling (Eastern Time)
       const todayString = getTodayString(); // "YYYY-MM-DD" in Eastern Time
@@ -5023,16 +5026,8 @@ router.get(
       const endOfLastWeek = new Date(startOfWeek);
       endOfLastWeek.setMilliseconds(-1);
 
-      // Active events (not completed, declined, cancelled)
-      const activeStatuses = ['new', 'in_process', 'scheduled', 'rescheduled'];
-      const activeEvents = allEventRequests.filter(event =>
-        activeStatuses.includes(event.status || '')
-      );
-
-      // This week's events (active events happening this week - excludes completed, cancelled, etc.)
-      const thisWeekEvents = allEventRequests.filter(event => {
-        // Only count active events
-        if (!activeStatuses.includes(event.status || '')) return false;
+      // This week's events (active events happening this week)
+      const thisWeekEvents = activeEvents.filter(event => {
         const eventDate = getEffectiveEventDate(event);
         if (!eventDate) return false;
         const date = parseDateOnly(eventDate);
@@ -5047,11 +5042,7 @@ router.get(
       };
 
       // Events happening today or tomorrow (upcoming deadlines)
-      const upcomingDeadlines = allEventRequests.filter(event => {
-        if (event.status === 'completed' || event.status === 'declined' ||
-            event.status === 'cancelled') {
-          return false;
-        }
+      const upcomingDeadlines = activeEvents.filter(event => {
         const eventDate = getEffectiveEventDate(event);
         if (!eventDate) return false;
         const date = parseDateOnly(eventDate);
@@ -5113,25 +5104,43 @@ router.get(
         return sum + Math.max(0, needed - assigned);
       }, 0);
 
-      // Last week's events for completion rate
-      // Only count events that were actually attempted (exclude cancelled/declined)
-      const lastWeekEvents = allEventRequests.filter(event => {
-        const eventDate = getEffectiveEventDate(event);
-        if (!eventDate) return false;
-        const date = parseDateOnly(eventDate);
-        if (!date || date < startOfLastWeek || date > endOfLastWeek) return false;
-        // Exclude events that were intentionally not attempted
-        if (event.status === 'cancelled' || event.status === 'declined') {
-          return false;
-        }
-        return true;
-      });
+      // Last week's completion rate — lightweight projection only (id + status +
+      // dates), scoped to last week's effective date range so we don't pull the
+      // entire completed-event history into memory. Effective date prefers
+      // scheduledEventDate over desiredEventDate (same as getEffectiveEventDate).
+      const lastWeekRows = await db
+        .select({
+          id: eventRequests.id,
+          status: eventRequests.status,
+          scheduledEventDate: eventRequests.scheduledEventDate,
+          desiredEventDate: eventRequests.desiredEventDate,
+        })
+        .from(eventRequests)
+        .where(
+          and(
+            isNull(eventRequests.deletedAt),
+            sql`${eventRequests.status} NOT IN ('cancelled', 'declined')`,
+            or(
+              and(
+                isNotNull(eventRequests.scheduledEventDate),
+                gte(eventRequests.scheduledEventDate, startOfLastWeek),
+                lte(eventRequests.scheduledEventDate, endOfLastWeek),
+              ),
+              and(
+                isNull(eventRequests.scheduledEventDate),
+                isNotNull(eventRequests.desiredEventDate),
+                gte(eventRequests.desiredEventDate, startOfLastWeek),
+                lte(eventRequests.desiredEventDate, endOfLastWeek),
+              ),
+            ),
+          ),
+        );
 
-      const lastWeekCompleted = lastWeekEvents.filter(event =>
-        event.status === 'completed'
+      const lastWeekCompleted = lastWeekRows.filter(
+        (event) => event.status === 'completed',
       ).length;
 
-      const lastWeekTotal = lastWeekEvents.length;
+      const lastWeekTotal = lastWeekRows.length;
       const completionRate = lastWeekTotal > 0
         ? Math.round((lastWeekCompleted / lastWeekTotal) * 100)
         : null;
@@ -5239,13 +5248,6 @@ router.get(
           const dA = parseDateOnly(a.eventDate)?.getTime() || 0;
           const dB = parseDateOnly(b.eventDate)?.getTime() || 0;
           return dA - dB;
-        };
-
-        const toDateOnlyString = (value: unknown): string | null => {
-          if (!value) return null;
-          if (value instanceof Date) return value.toISOString().slice(0, 10);
-          if (typeof value === 'string') return value.slice(0, 10);
-          return null;
         };
 
         const sortRawEventsByDateAsc = (a: any, b: any) => {


### PR DESCRIPTION
## Summary
- Close the manual create-event dialog as soon as the save succeeds, and refresh event lists in the background so users are no longer stuck on "Creating..." (and canceling after the event already saved).
- Geocode new event addresses asynchronously so create no longer waits on Google/OSM.
- Speed up dashboard Today / Volunteers widgets by querying active statuses only (instead of the full event-requests table) and adding timeout/retry UI.

## Test plan
- [ ] Manually create an event from Event Requests → dialog closes promptly after save, toast appears, event shows in the correct tab shortly after
- [ ] Create an event with an address → event saves immediately; coordinates appear on map after a short delay / refresh
- [ ] Cancel is not needed mid-create; if canceled after toast, no duplicate create occurs
- [ ] Dashboard Today and Volunteers widgets render instead of hanging on skeletons
- [ ] Low-volume / group forecast still shows upcoming scheduled/in-process/rescheduled events


Made with [Cursor](https://cursor.com)